### PR TITLE
Fix Docker Build Error for kali-sandbox on Mac (ARM)

### DIFF
--- a/mcp/kali-sandbox/Dockerfile
+++ b/mcp/kali-sandbox/Dockerfile
@@ -38,9 +38,12 @@ RUN apt-get install -y --fix-missing \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Go (required for naabu and nuclei)
-RUN wget -q https://go.dev/dl/go1.21.5.linux-amd64.tar.gz \
-    && tar -C /usr/local -xzf go1.21.5.linux-amd64.tar.gz \
-    && rm go1.21.5.linux-amd64.tar.gz
+# Handle ARM64 (Apple Silicon) vs AMD64 automatically
+RUN ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "arm64" ]; then GO_ARCH="arm64"; else GO_ARCH="amd64"; fi && \
+    wget -q https://go.dev/dl/go1.25.7.linux-$GO_ARCH.tar.gz && \
+    tar -C /usr/local -xzf go1.25.7.linux-$GO_ARCH.tar.gz && \
+    rm go1.25.7.linux-$GO_ARCH.tar.gz
 
 ENV PATH="${PATH}:/usr/local/go/bin:/root/go/bin"
 ENV GOPATH="/root/go"


### PR DESCRIPTION
**Problem**
The build was failing because:

Outdated Go Version: The Dockerfile was using Go 1.21.5, while the latest versions of ProjectDiscovery tools (like nuclei) now require Go >= 1.24.2.
Architecture Mismatch: The Go binary was hardcoded to amd64, causing it to fail on your ARM64 (Apple Silicon) Mac during the go install process (specifically a gcc error unrecognized command-line option '-m64').


**Solution**

I implemented the following changes:
Updated Go to version 1.25.7 (latest stable).
Modified the Dockerfile to be architecture-aware. It now automatically detects if the build is running on amd64 or arm64 and downloads the appropriate Go binary.