### PR TITLE
fix(webapp): enable Allow/Deny buttons for fireteam member waves

### DIFF
--- a/webapp/src/app/graph/components/AIAssistantDrawer/ChatArea.tsx
+++ b/webapp/src/app/graph/components/AIAssistantDrawer/ChatArea.tsx
@@ -263,7 +263,7 @@ export function ChatArea({
                 missingApiKeys={missingApiKeys}
                 onAddApiKey={openApiKeyModal}
                 onToolConfirmation={handleTimelineToolConfirmation}
-                toolConfirmationDisabled={isLoading}
+                toolConfirmationDisabled={false}
                 onToolStop={handleToolStop}
               />
             )


### PR DESCRIPTION
## Summary

In fireteam mode with parallel members, the Allow button on each member's pending-approval card was permanently disabled — preventing operators from approving any wave. This change replaces the dynamic `isLoading` binding with a static `false`, since member-card buttons are already gated by `item.status === 'pending_approval'` upstream.

## Problem

`webapp/src/app/graph/components/AIAssistantDrawer/ChatArea.tsx:266` has:

    toolConfirmationDisabled={isLoading}

In fireteam mode, at least one of N parallel members is always thinking, so `isLoading` is always `true`. Result: every member's Allow button is disabled forever; the operator cannot approve.

## Fix

Single-line change:

    toolConfirmationDisabled={false}

The button is already conditionally rendered/active based on `item.status === 'pending_approval'`, so removing the redundant `isLoading` guard is safe.

## Testing

1. Start a session that deploys a fireteam (multi-target prompt).
2. Wait for any member to escalate a wave.
3. Pre-patch: Allow button is greyed; cursor shows the no-entry icon.
4. Post-patch: Allow button is clickable; click sends `operator APPROVED` to the agent; tools execute.

## Risk

Minimal. The status-based guard at the parent level remains in place; worst case is that a click during agent mid-thought is queued rather than suppressed, and the agent's confirmation registry already deduplicates.
