### PR TITLE
fix(agent): preserve original LLM exception in guardrail fail-closed message

### DIFF
--- a/agentic/orchestrator_helpers/guardrail.py
+++ b/agentic/orchestrator_helpers/guardrail.py
@@ -161,6 +161,7 @@ async def _invoke_guardrail(llm: Any, user_prompt: str) -> dict[str, Any]:
         HumanMessage(content=user_prompt),
     ]
 
+    last_error=None
     for attempt in range(3):
         try:
             response = await llm.ainvoke(messages)
@@ -177,7 +178,7 @@ async def _invoke_guardrail(llm: Any, user_prompt: str) -> dict[str, Any]:
             logger.warning(f"Guardrail attempt {attempt + 1}: no JSON in response")
 
         except Exception as e:
-            logger.warning(f"Guardrail attempt {attempt + 1} error: {e}")
+            last_error=e; logger.warning(f"Guardrail attempt {attempt + 1} error: {e}")
 
     # All retries exhausted — raise so callers can decide fail-open vs fail-closed
-    raise RuntimeError("Guardrail LLM check failed after 3 attempts")
+    raise RuntimeError(f"Guardrail LLM check failed after 3 attempts. Last error: {last_error}") from last_error


### PR DESCRIPTION
## Summary

When the guardrail's LLM check fails (network error, 529 overloaded, etc.), the existing fail-closed path raises a hardcoded `RuntimeError("Guardrail LLM check failed after 3 attempts")` — discarding the actual exception. The UI then shows a misleading "Scope Guardrail: Check Failed" message that suggests a scope or auth problem, when the real cause is upstream LLM capacity.

## Problem

`agentic/orchestrator_helpers/guardrail.py:184`:

    raise RuntimeError("Guardrail LLM check failed after 3 attempts")

The original exception is logged at WARN but discarded from the raise. Operators chase scope/auth diagnostics for what's actually an Anthropic 529 or network blip.

## Fix

Capture the last exception in `last_error` and include it in the raised message, plus chain via `raise ... from last_error`:

    last_error = None
    for attempt in range(3):
        ...
        except Exception as e:
            last_error = e
            logger.warning(f"Guardrail attempt {attempt + 1} error: {e}")
    raise RuntimeError(
        f"Guardrail LLM check failed after 3 attempts. Last error: {last_error}"
    ) from last_error

## Testing

1. Block egress to api.anthropic.com or trigger during a known 529 window.
2. Start any pentest.
3. Pre-patch: UI shows "Scope Guardrail: Check Failed" with no upstream error context.
4. Post-patch: UI shows e.g. "Last error: Error code: 529 - overloaded_error - Overloaded" — operator immediately knows it's capacity, not scope.

## Risk

Minimal. Only changes the format of an existing terminal exception.