### PR TITLE
chore(compose): set MCP_NUCLEI_URL to in-cluster kali-sandbox endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -408,6 +408,7 @@ services:
       WS_MAX_MESSAGE_SIZE: "10485760"
       # MCP tool servers (internal docker network)
       MCP_NETWORK_RECON_URL: http://kali-sandbox:8000/sse
+      MCP_NUCLEI_URL: http://kali-sandbox:8002/sse
       MCP_NMAP_URL: http://kali-sandbox:8004/sse
       MCP_METASPLOIT_URL: http://kali-sandbox:8003/sse
       MCP_PLAYWRIGHT_URL: http://kali-sandbox:8005/sse


### PR DESCRIPTION
## Summary

Adds `MCP_NUCLEI_URL: http://kali-sandbox:8002/sse` to the agent service environment in `docker-compose.yml`, so the agent connects to the in-cluster nuclei MCP server via the docker network rather than relying on a host-gateway default that doesn't work inside a container.

## Problem

Without this env var, the agent's MCP layer falls back to a default that resolves `host.docker.internal:8002` from inside the agent container — i.e., the VPS host gateway, where nothing is listening. The MCP layer registers servers via `asyncio.gather(...)`; one connection failure raises and aborts the rest, so a single wrong nuclei URL nukes the entire tool catalog. Logs show `Tool not found` for httpx, naabu, etc. unrelated to nuclei.

## Fix

Add to the `agent` service `environment:` block in `docker-compose.yml`, alongside the existing `MCP_*_URL` entries:

    MCP_NUCLEI_URL: http://kali-sandbox:8002/sse

## Testing

1. `docker compose up -d --build agent`
2. `docker logs redamon-agent | grep "tools loaded"` — expect 23 tools loaded (or current count) with no `Tool not found` for the standard set.

## Risk

None — strictly adds explicit configuration. If a deployment overrides this with a different nuclei MCP endpoint, this default is shadowed.