### PR TITLE
chore(agent): set max_retries and default_request_timeout on ChatAnthropic clients

### DIFF
--- a/agentic/orchestrator_helpers/llm_setup.py
+++ b/agentic/orchestrator_helpers/llm_setup.py
@@ -119,6 +119,14 @@ def setup_llm(
                 default_headers=custom_llm_config.get("defaultHeaders") or {},
                 timeout=float(custom_llm_config.get("timeout", 120)),
                 max_tokens=custom_llm_config.get("maxTokens", 16384),
+                # FIX: Survive transient VPS network blips. SDK default is
+                # max_retries=2 with ~3s total budget. Network spikes on this
+                # path can last 5-10s, so 2 retries fail before the spike
+                # clears. 5 retries spread over ~30s ride out any reasonable
+                # blip. default_request_timeout=60s overrides httpx's default
+                # 5s connect timeout that fails mid-handshake during spikes.
+                max_retries=5,
+                default_request_timeout=300.0,  # 5 min - generous for Opus heavy prompts but trips before Anthropic 10-min server timeout
             )
             if _anthropic_supports_temperature(anth_model):
                 anth_kwargs["temperature"] = custom_llm_config.get("temperature", 0)
@@ -294,6 +302,10 @@ def setup_llm(
             model=api_model,
             api_key=anthropic_api_key,
             max_tokens=16384,
+            # FIX: Survive transient VPS network blips. See comment on the
+            # custom-provider path above for full rationale.
+            max_retries=5,
+            default_request_timeout=300.0,  # 5 min - generous for Opus heavy prompts but trips before Anthropic 10-min server timeout
         )
         if _anthropic_supports_temperature(api_model):
             anth_kwargs["temperature"] = 0


### PR DESCRIPTION
## Summary

Adds `max_retries=5` and `default_request_timeout=300.0` to both `ChatAnthropic(...)` instantiations in `agentic/orchestrator_helpers/llm_setup.py`. Improves resilience to brief network blips and Anthropic-side transient errors without trips of the SDK's 10-minute server-side cap.

## Problem

Without retry configuration, the SDK defaults to 2 retries with a short connect timeout. Brief connectivity dips (sub-10s) terminated entire sessions with `Connection error.` — visible in production runs from constrained network paths.

## Fix

Both `ChatAnthropic(...)` constructors in `llm_setup.py` (lines ~125 and ~300) now pass:

    max_retries=5,
    default_request_timeout=300.0,  # 5 min — generous for Opus heavy prompts
                                    # but trips before Anthropic 10-min server timeout

`max_retries` and `default_request_timeout` are documented public kwargs of `langchain_anthropic.ChatAnthropic`.

## Note

This patch covers the root agent's call sites. The fireteam-member ainvoke is wrapped separately and has its own retry guard — see related PR `fix(agent): retry transient LLM errors in fireteam member ainvoke`.

## Testing

Synthetic: run a session, drop the network briefly mid-call. Pre-patch the agent dies with `Connection error.`; post-patch the SDK retries transparently and the session resumes.

## Risk

Low. Both values are conservative. 300s is below Anthropic's 10-min server-side cap. `max_retries=5` is a safe increase from the SDK default.