### PR TITLE
fix(agent): preserve _current_plan / _current_step across operator approval

### DIFF
--- a/agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py
+++ b/agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py
@@ -877,6 +877,22 @@ async def fireteam_member_think_node(
     if is_dangerous:
         pending = _build_pending_confirmation(decision, state)
         update["_pending_confirmation"] = pending
+        # FIX: Populate _current_plan / _current_step now so they survive
+        # the await round-trip. Without this, the await node returns to
+        # the router with these fields unset and the router falls back to
+        # fireteam_think -> infinite plan/approve loop, no tool execution.
+        if decision.action == "plan_tools" and decision.tool_plan:
+            update["_current_plan"] = decision.tool_plan.model_dump()
+        elif decision.action == "use_tool":
+            update["_current_step"] = {
+                "step_id": uuid4().hex,
+                "iteration": current_iter + 1,
+                "phase": state.get("current_phase"),
+                "tool_name": decision.tool_name,
+                "tool_args": decision.tool_args or {},
+                "thought": decision.thought,
+                "reasoning": decision.reasoning,
+            }
         # Even though we're escalating the NEW decision, the PREVIOUS
         # single-tool step (if any) is now completed — its output was the
         # input to this think call. Signal it to the streaming layer so the


### PR DESCRIPTION
## Summary

Fixes an infinite re-plan loop that occurred when a fireteam member escalated a `plan_tools` wave for operator approval. After approve, the member would loop back to "thinking" indefinitely, never executing tools.

## Problem

In `fireteam_member_think_node.py`, the `is_dangerous` branch at ~line 877 returns early, **before** the non-dangerous path's `update["_current_plan"] = decision.tool_plan.model_dump()` (~line 917). When the await node clears `_pending_confirmation` on approve, the router checks `action == "plan_tools" and state.get("_current_plan")`. Because `_current_plan` was never set, that condition is false; the router falls back to `return "fireteam_think"` and the member re-plans the same wave.

Symptom in logs: `Iteration 2/20`, `Iteration 3/20`, ... with no `EXECUTE PLAN` line between, despite operator clicking Approve.

## Fix

Inside the `is_dangerous` branch, immediately after `update["_pending_confirmation"] = pending`, populate the same fields that the non-dangerous path populates further down:

    if decision.action == "plan_tools" and decision.tool_plan:
        update["_current_plan"] = decision.tool_plan.model_dump()
    elif decision.action == "use_tool":
        update["_current_step"] = {
            "step_id": uuid4().hex,
            "iteration": current_iter + 1,
            "phase": state.get("current_phase"),
            "tool_name": decision.tool_name,
            "tool_args": decision.tool_args or {},
            "thought": decision.thought,
            "reasoning": decision.reasoning,
        }

## Testing

1. Start a fireteam session that deploys a wave with dangerous tools.
2. Click Approve when prompted.
3. Pre-patch: `docker logs redamon-agent` shows successive `Iteration N/20` lines with no `EXECUTE PLAN` between.
4. Post-patch: `EXECUTE PLAN` appears immediately after `operator APPROVED`, and iteration 2 plans a *new* wave (not a duplicate of iteration 1).

## Risk

Low. Only adds two assignments mirroring existing logic in the non-dangerous path. The reject path (which clears `_decision` / `_current_plan`) is unaffected.