### PR TITLE
fix(agent): retry transient LLM errors in fireteam member ainvoke

### DIFF
--- a/agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py
+++ b/agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py
@@ -773,13 +773,33 @@ async def fireteam_member_think_node(
                 )
             ))
 
-        try:
-            response = await llm.ainvoke(llm_messages)
-        except Exception as exc:
-            logger.error("[%s] member %s LLM call failed: %s", session_id, member_id, exc)
+        # P4 FIX: retry on transient LLM connection/overload errors before giving up.
+        response = None
+        last_conn_exc = None
+        for _conn_attempt in range(3):
+            try:
+                response = await llm.ainvoke(llm_messages)
+                last_conn_exc = None
+                break
+            except Exception as exc:
+                last_conn_exc = exc
+                err_str = str(exc).lower()
+                is_transient = any(s in err_str for s in [
+                    'connection', 'timeout', 'timed out', '529', 'overloaded',
+                    'rate_limit', 'rate limit', 'apiconnectionerror',
+                ])
+                logger.warning(
+                    "[%s] member %s LLM attempt %d/3 error (transient=%s): %s",
+                    session_id, member_id, _conn_attempt + 1, is_transient, exc
+                )
+                if not is_transient:
+                    break
+                await asyncio.sleep(min(2 ** _conn_attempt, 8))
+        if response is None:
+            logger.error("[%s] member %s LLM call failed after 3 attempts: %s", session_id, member_id, last_conn_exc)
             return {
                 "task_complete": True,
-                "completion_reason": f"llm_error: {exc}",
+                "completion_reason": f"llm_error after 3 attempts: {last_conn_exc}",
             }
 
         raw_content = normalize_content(response.content if hasattr(response, "content") else response)


### PR DESCRIPTION
## Summary

Wraps the fireteam member's `await llm.ainvoke(llm_messages)` in a 3-attempt retry loop covering connection errors, timeouts, HTTP 529 overloaded, and rate-limit responses. Mirrors the retry shape used in `guardrail.py`.

## Problem

`fireteam_member_think_node.py:775` has:

    try:
        response = await llm.ainvoke(llm_messages)
    except Exception as exc:
        logger.error(...)
        return {"task_complete": True, "completion_reason": f"llm_error: {exc}"}

A single transient error (network blip, 529) terminates the entire member iteration. The root agent's `max_retries=5` (set in `llm_setup.py`) doesn't propagate to this wrap — the exception is caught here before the SDK can retry transparently.

## Fix

3-attempt retry classifying transient (connection / timeout / 529 / overloaded / rate_limit) vs non-transient errors. Exponential backoff `min(2 ** attempt, 8)` seconds. Non-transient exceptions break out immediately to preserve original behavior for auth/SDK errors.

## Testing

1. Start a fireteam.
2. Mid-wave, simulate a network blip (e.g. drop the interface for 4s).
3. Pre-patch: member terminates with single `LLM call failed: Connection error.` line and `task_complete=true`.
4. Post-patch: `member <id> LLM attempt 1/3 error (transient=True)` followed by `attempt 2/3` (or success). Member resumes normally.

## Risk

Low. Only the failure path changes. Successful first-try calls take the `break` and exit unchanged. Non-transient exceptions break out without retrying.