### PR TITLE
fix(fireteam): log raw LLM responses in member think_node

### DIFF
--- a/agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py
+++ b/agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py
@@ -950,6 +950,15 @@ async def fireteam_member_think_node(
         input_tokens_this_turn += int(_usage.get("input_tokens", 0) or 0)
         output_tokens_this_turn += int(_usage.get("output_tokens", 0) or 0)
 
+        logger.info(f"\n{'='*60}")
+        logger.info(
+            f"MEMBER LLM RAW RESPONSE - [{session_id}] member {member_id} "
+            f"iter {current_iter} (attempt {attempt+1}/{max_retries})"
+        )
+        logger.info(f"{'='*60}")
+        logger.info(f"{raw_content}")
+        logger.info(f"{'='*60}\n")
+
         decision, parse_error = try_parse_llm_decision(raw_content)
         if decision is None:
             # JSON / Pydantic shape error: loop and retry.


### PR DESCRIPTION
### Summary

The fireteam member think node now logs the raw LLM response immediately after capture, mirroring the existing pattern in the root think node. Without this, debugging a member's emissions was impossible because every existing log line came from a parsed Pydantic model and could not show what the LLM actually sent.

### Problem

`agentic/orchestrator_helpers/nodes/think_node.py:494-498` dumps the full raw LLM response to `logger.info` immediately after `normalize_content(...)` and before `try_parse_llm_decision(...)`. The fireteam equivalent at `agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py:947-953` captures the same payload (`raw_content = normalize_content(...)`) but flows it directly into `try_parse_llm_decision(raw_content)` with no logger call in between.

The member node does log post-parse extracts (THOUGHT / REASONING / ACTION / ANALYSIS / COMPLETION_REASON), but those come from the validated `LLMDecision` Pydantic model — they cannot answer "did the LLM emit field X that the parser dropped?" Loop behaviour is unaffected; this is purely an observability gap that blocks empirical debugging of member-LLM behaviour.

### Fix

`agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py` — added a 9-line `logger.info` block between the token-usage accounting (line 951) and the `try_parse_llm_decision(raw_content)` call (now line 962). The block mirrors the root think node's `={60}` banner format. The header line uses tag `MEMBER LLM RAW RESPONSE` (distinct from the root's `LLM RAW RESPONSE`) and carries all four identifiers — `session_id`, `member_id`, `current_iter`, and `attempt+1/max_retries` — so a single grep match yields full context for tracing a line back to its specific member and iteration. Used `current_iter` (the member's per-run counter in this scope) rather than a generic `iteration` name; `attempt` is the existing retry-loop variable.

### Testing

Static verification only — runtime testing was impractical because triggering a fireteam wave requires creating a project and kicking off a recon in the webapp UI, which is a hands-on workflow rather than a scripted reproduction step.

What was verified statically:

- `python3 -c "import ast; ast.parse(...)"` parses the modified file cleanly.
- The five referenced variables are all in scope at the insertion point: `session_id` (line 757), `member_id` (line 755), `current_iter` (line 842), `attempt` (loop variable at line 910), `max_retries` (line 895).
- `raw_content` is the variable assigned by `normalize_content(...)` on line 947, immediately above the new block.
- Placement is between `normalize_content(...)` and `try_parse_llm_decision(raw_content)`, matching the root think node's pattern.

### Risk

Very low. The change is additive (5 `logger.info` lines, no control-flow or behavioural change), inside an `INFO`-level path that callers can already filter, and only fires per LLM attempt — there is no hot inner loop. The only real downside is log-file size growth for projects that run many member iterations; sites with aggressive log-volume limits may want to pin this behind a debug flag in a follow-up, but for the bug-bash use case the verbosity is the point.

---