### PR TITLE
fix(fireteam): run analysis-write before dangerous-tool escalation in member think_node

### DIFF
--- a/agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py
+++ b/agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py
@@ -1100,54 +1100,6 @@ async def fireteam_member_think_node(
     # defining it here, the is_dangerous branch crashed with NameError.
     analysis = decision.output_analysis
 
-    if is_dangerous:
-        pending = _build_pending_confirmation(decision, state)
-        update["_pending_confirmation"] = pending
-        # FIX: Populate _current_plan / _current_step now so they survive
-        # the await round-trip. Without this, the await node returns to
-        # the router with these fields unset and the router falls back to
-        # fireteam_think -> infinite plan/approve loop, no tool execution.
-        if decision.action == "plan_tools" and decision.tool_plan:
-            update["_current_plan"] = decision.tool_plan.model_dump()
-        elif decision.action == "use_tool":
-            update["_current_step"] = {
-                "step_id": uuid4().hex,
-                "iteration": current_iter + 1,
-                "phase": state.get("current_phase"),
-                "tool_name": decision.tool_name,
-                "tool_args": decision.tool_args or {},
-                "thought": decision.thought,
-                "reasoning": decision.reasoning,
-            }
-        # Even though we're escalating the NEW decision, the PREVIOUS
-        # single-tool step (if any) is now completed — its output was the
-        # input to this think call. Signal it to the streaming layer so the
-        # UI flips the prior tool card from `running` to `success/error`.
-        # Without this, the frontend sees: tool_start → (never completes) →
-        # pending-approval card, and the prior tool stays stuck visually.
-        if has_pending_single_output and prev_step:
-            completed_prev = dict(prev_step)
-            if analysis is not None:
-                completed_prev["output_analysis"] = (
-                    analysis.interpretation
-                    or (prev_step.get("tool_output") or "")
-                )[:20000]
-                completed_prev["actionable_findings"] = list(analysis.actionable_findings or [])
-                completed_prev["recommended_next_steps"] = list(analysis.recommended_next_steps or [])
-            else:
-                completed_prev["output_analysis"] = (prev_step.get("tool_output") or "")[:20000]
-                completed_prev["actionable_findings"] = []
-                completed_prev["recommended_next_steps"] = []
-            update["_completed_step"] = completed_prev
-        logger.info(
-            "[%s] member %s escalating dangerous tool for parent approval: %s",
-            session_id, member_id,
-            decision.tool_name or [s.tool_name for s in (decision.tool_plan.steps if decision.tool_plan else [])],
-        )
-        # Router will send us to fireteam_await_confirmation because
-        # _pending_confirmation is set.
-        return update
-
     # If action is complete, ensure task_complete is True so the router exits.
     if decision.action == "complete":
         update["task_complete"] = True
@@ -1499,5 +1451,55 @@ async def fireteam_member_think_node(
             pass  # update["_current_plan"] already set to the new plan above
         else:
             update["_current_plan"] = None
+
+    # Dangerous-tool escalation runs AFTER analysis-write so the prior wave's
+    # chain_findings, target_info merge, and Neo4j writes commit before we
+    # pause for operator approval. `_pending_confirmation` is the router's
+    # signal to fireteam_await_confirmation — its placement in this function
+    # does not affect routing, only whether analysis-write fires first.
+    if is_dangerous:
+        pending = _build_pending_confirmation(decision, state)
+        update["_pending_confirmation"] = pending
+        # Populate _current_plan / _current_step so they survive the await
+        # round-trip. Without this, the await node returns to the router
+        # with these fields unset and the router falls back to fireteam_think
+        # -> infinite plan/approve loop, no tool execution.
+        if decision.action == "plan_tools" and decision.tool_plan:
+            update["_current_plan"] = decision.tool_plan.model_dump()
+        elif decision.action == "use_tool":
+            update["_current_step"] = {
+                "step_id": uuid4().hex,
+                "iteration": current_iter + 1,
+                "phase": state.get("current_phase"),
+                "tool_name": decision.tool_name,
+                "tool_args": decision.tool_args or {},
+                "thought": decision.thought,
+                "reasoning": decision.reasoning,
+            }
+        # Even though we're escalating the NEW decision, the PREVIOUS
+        # single-tool step (if any) is now completed — its output was the
+        # input to this think call. Signal it to the streaming layer so the
+        # UI flips the prior tool card from `running` to `success/error`.
+        # Without this, the frontend sees: tool_start → (never completes) →
+        # pending-approval card, and the prior tool stays stuck visually.
+        if has_pending_single_output and prev_step:
+            completed_prev = dict(prev_step)
+            if analysis is not None:
+                completed_prev["output_analysis"] = (
+                    analysis.interpretation
+                    or (prev_step.get("tool_output") or "")
+                )[:20000]
+                completed_prev["actionable_findings"] = list(analysis.actionable_findings or [])
+                completed_prev["recommended_next_steps"] = list(analysis.recommended_next_steps or [])
+            else:
+                completed_prev["output_analysis"] = (prev_step.get("tool_output") or "")[:20000]
+                completed_prev["actionable_findings"] = []
+                completed_prev["recommended_next_steps"] = []
+            update["_completed_step"] = completed_prev
+        logger.info(
+            "[%s] member %s escalating dangerous tool for parent approval: %s",
+            session_id, member_id,
+            decision.tool_name or [s.tool_name for s in (decision.tool_plan.steps if decision.tool_plan else [])],
+        )
 
     return update


### PR DESCRIPTION
### Summary

Fireteam-member think nodes were silently discarding the previous wave's analysis (chain findings, extracted target info, Neo4j step/finding writes) whenever the LLM's next decision planned a dangerous tool. Because the dangerous-tool set includes every common recon tool (httpx, curl, nuclei, katana, kali_shell, …), this fired on every iteration of a typical recon specialist — so members ran their tools, the LLM produced rich `output_analysis`, and the resulting `chain_findings_memory` still finished at `[]`. The fix is a structural reorder: the dangerous-tool escalation block now runs AFTER the analysis-write branches, mirroring the root think node.

### Problem

`agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py` had an early `return update` inside the `if is_dangerous:` block (formerly at line 1158) that ran BEFORE the analysis-write branches at `:1190` (single-tool) and `:1325` (plan-wave). When the LLM's next decision in any given iteration planned a tool in `DANGEROUS_TOOLS` (`agentic/project_settings.py:21-27`), control exited the node and never reached the analysis writes. The prior wave's `output_analysis.chain_findings` was parsed by Pydantic, logged as a `[member_id] ANALYSIS: …` line, and then dropped. `target_info` was never merged via `_merge_extracted_info_into_target`. `chain_graph_writer.fire_record_step` / `fire_record_finding` were never called for plan-wave steps.

Symptom for an operator: a recon specialist completes 5 iterations, every wave is approved and executes successfully, the agent log shows rich `ANALYSIS:` lines describing services, CVEs, banners, and discovered endpoints — and the final collect still reports `findings=0` with `delta_keys=[]`.

The structural argument that this was unintentional is direct: the root `agentic/orchestrator_helpers/nodes/think_node.py` orders its analysis writes (e.g. `fire_record_finding` at `:807` and `:1055`) BEFORE its tool-confirmation gate at `:1218-1257`. The gate just sets `awaiting_tool_confirmation` / `tool_confirmation_pending` on the updates dict and falls through to `return updates`. The member's ordering was the inverse.

### Fix

`agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py` — relocated the `if is_dangerous:` block (the `_build_pending_confirmation` call, `_pending_confirmation` write, `_current_plan`/`_current_step` setup, `_completed_step` partial update for single-tool, and escalation log line) from its previous position (right after the stall counter / `step_chain_update` merge, before the analysis writes) to AFTER the plan-wave analysis-write block, immediately before the final `return update`.

The relocation is exact — the block was moved as a unit, with the only substantive change being the removal of the `return update` at the end of the block (the function now falls through to the unconditional `return update` at the bottom). The banner comment above the block was updated to explain the new ordering invariant. Router behaviour is preserved because `fireteam_member_graph.py:33-34` routes to `fireteam_await_confirmation` based on `state.get("_pending_confirmation")`, which is set on the update dict regardless of where in the function the block runs.

Two minor redundancies are intentionally left in place:
- The `_current_plan` / `_current_step` assignments inside the moved block (now lines 1476-1487) duplicate the assignments earlier in the function (now lines 1119-1130). After the reorder both run; they produce identical values, so the second write is a no-op. Removing them would be a separate logical change.
- The `_completed_step` partial update inside the moved block (lines 1494-1507) overwrites the equivalent value set by the single-tool analysis-write block (around line 1247). Both build a dict from `prev_step` with `output_analysis` / `actionable_findings` / `recommended_next_steps`. Equivalent content; harmless overwrite.

Net diff: +50 / -48 lines.

### Testing

Static verification only. Runtime testing was impractical for this turn because triggering the fix requires creating a project, launching a fireteam wave with at least one recon-only specialist, approving each operator-confirmation popup, and then querying Postgres or Neo4j to verify `chain_findings_memory` / `FireteamMember.findingsCount` — a hands-on workflow rather than a scripted reproduction step. The agent container also bakes source into the image (no bind-mount on `agentic/`), so a `docker compose build agent` would be needed before any runtime test could exercise the change.

Static verification covered:

1. `python3 -c "import ast; ast.parse(...)"` — module parses cleanly.
2. Control-flow trace of three paths through the function:
   - **No pending output, safe new decision:** analysis-write guard conditions FALSE → skipped; gate condition FALSE → skipped. Identical to pre-fix.
   - **Pending output, safe new decision:** analysis-write fires; gate condition FALSE → skipped. Identical to pre-fix.
   - **Pending output, dangerous new decision:** analysis-write fires (writes `chain_findings_memory`, `target_info`, `execution_trace`, Neo4j) — this is the fix — then gate fires, setting `_pending_confirmation` and the redundant `_current_plan`/`_current_step`/`_completed_step` overwrites. Router still routes to `fireteam_await_confirmation`.
3. Verified that the single-tool analysis-write's `if decision.action != "use_tool": update["_current_step"] = None` clearing logic still cooperates correctly: it clears stale prev-step state for dangerous-plan_tools (because the new step is captured in `_current_plan`, not `_current_step`) and does not clobber the new use_tool step (the guard is false in that case).
4. Verified that the plan-wave block's `if decision.action == "plan_tools" and decision.tool_plan: pass else: update["_current_plan"] = None` still correctly preserves a newly-planned dangerous wave.

### Risk

Medium. The reorder touches the core of the member ReAct loop and a path that pauses on operator approval — the dangerous-tool confirmation flow itself MUST still escalate and pause. Reviewers should pay particular attention to:

- The `_pending_confirmation` write still happening in the relocated block (preserved at line 1471 in the new position) — this is the router's signal.
- The `_completed_step` and `_current_plan`/`_current_step` redundancies — these write twice in the dangerous path. The second write produces an equivalent value but a slightly different `step_id` uuid for the new-use_tool-dangerous case (because the moved block's `uuid4().hex` runs after the earlier block's `uuid4().hex`). Both uuids are fresh and unobserved externally, so the final value is what matters; the difference is intermediate-only.
- The `if decision.action != "use_tool"` clearing logic interaction with the new step-setting order. Walked manually above; no behaviour change.

Backward compatibility: this is server-only Python; no schema, message, or API surface changes. Members that have never planned dangerous tools see no behaviour change.

---