### PR TITLE
fix(fireteam): preserve in-flight member state on wave timeout

### DIFF
--- a/agentic/orchestrator_helpers/nodes/fireteam_deploy_node.py
+++ b/agentic/orchestrator_helpers/nodes/fireteam_deploy_node.py
@@ -361,6 +361,38 @@ def _timeout_result(spec: dict, member_id: str, wall_s: float) -> dict:
     ).model_dump()
 
 
+def _timeout_result_from_snapshot(
+    snapshot: Optional[dict],
+    spec: dict,
+    member_id: str,
+    wall_s: float,
+) -> dict:
+    """Build a timeout-labeled result from an in-flight member snapshot.
+
+    The wave-timeout handler cancels in-flight tasks, which destroys the
+    closure-local ``final_state`` inside ``_run_one``. To preserve real
+    iteration/token/findings counts for productive work done before the
+    cancellation, ``_run_one`` registers a reference to its ``final_state``
+    in the outer-scope ``member_snapshots`` dict at startup; the in-place
+    ``.update(node_update)`` calls during the astream loop keep that
+    reference current. Here we reuse ``_result_from_final_state`` to extract
+    those counts and then override status/completion_reason to mark the
+    member as timed out.
+
+    Falls back to the all-zeros ``_timeout_result`` when no snapshot exists
+    (member cancelled before any state update).
+    """
+    if not snapshot:
+        return _timeout_result(spec, member_id, wall_s)
+    result = _result_from_final_state(snapshot, spec, member_id, wall_s)
+    result["status"] = "timeout"
+    result["completion_reason"] = "wave_timeout"
+    # Suppress any pending operator-approval signal: the member is
+    # terminating, not awaiting confirmation.
+    result["pending_confirmation"] = None
+    return result
+
+
 def _error_result(spec: dict, member_id: str, exc: BaseException, wall_s: float) -> dict:
     return FireteamMemberResult(
         member_id=member_id,
@@ -560,6 +592,14 @@ async def fireteam_deploy_node(
     from orchestrator_helpers.member_streaming import scoped_member_streaming
     from orchestrator_helpers.streaming import emit_streaming_events
 
+    # Snapshot map: each _run_one registers a reference to its closure-local
+    # ``final_state`` here, keyed by member_id. The in-place mutations inside
+    # the astream loop (`final_state.update(node_update)`) keep these
+    # references current. On wave timeout, the outer handler reads from this
+    # map via _timeout_result_from_snapshot to preserve real iteration/
+    # token/findings counts for productive work done before cancellation.
+    member_snapshots: dict = {}
+
     async def _run_one(spec: dict, member_id: str) -> dict:
         async with sem:
             member_state = _build_member_state(state, spec, member_id, fireteam_id_key)
@@ -581,6 +621,10 @@ async def fireteam_deploy_node(
                 except Exception:
                     pass
             final_state = dict(member_state)
+            # Register the snapshot reference. The outer wave-timeout handler
+            # reads this to recover real iter/token/findings counts even when
+            # the member's task is cancelled mid-loop.
+            member_snapshots[member_id] = final_state
             try:
                 # Activate the member-scoped streaming proxy. While this
                 # context is active, resolve_streaming_callback returns the
@@ -620,10 +664,12 @@ async def fireteam_deploy_node(
                 )
             except asyncio.CancelledError:
                 logger.info("[%s] wave=%s member=%s CANCELLED", session_id, fireteam_id_key, member_id)
-                # Propagate cancellation to gather. Per-member DB persistence on
-                # wave-timeout happens in the outer TimeoutError handler below,
-                # which has access to the full results list (including real
-                # iteration/token counts) and can label status correctly.
+                # Propagate cancellation to gather. The outer TimeoutError
+                # handler builds the per-member result via
+                # _timeout_result_from_snapshot, which reads this member's
+                # last in-flight final_state from member_snapshots (kept in
+                # sync via in-place .update() calls in the astream loop
+                # above). That preserves real iter/token/findings counts.
                 raise
             except Exception as exc:
                 logger.exception("[%s] wave=%s member=%s CRASHED", session_id, fireteam_id_key, member_id)
@@ -696,9 +742,15 @@ async def fireteam_deploy_node(
                     results.append(t.result() if isinstance(t.result(), dict)
                                    else _error_result(m, mid, t.result(), time.monotonic() - wave_start))
                 else:
-                    results.append(_timeout_result(m, mid, time.monotonic() - wave_start))
+                    results.append(_timeout_result_from_snapshot(
+                        member_snapshots.get(mid), m, mid,
+                        time.monotonic() - wave_start,
+                    ))
             except asyncio.CancelledError:
-                results.append(_timeout_result(m, mid, time.monotonic() - wave_start))
+                results.append(_timeout_result_from_snapshot(
+                    member_snapshots.get(mid), m, mid,
+                    time.monotonic() - wave_start,
+                ))
             except Exception as e:
                 results.append(_error_result(m, mid, e, time.monotonic() - wave_start))
         # Persist per-member timeout to Postgres. Without this, members whose

--- a/agentic/tests/test_fireteam_regressions.py
+++ b/agentic/tests/test_fireteam_regressions.py
@@ -605,5 +605,172 @@ class WaveTimeoutWebsocketEmitRegression(unittest.IsolatedAsyncioTestCase):
                              f"per-member emit must carry status=timeout; got {call.kwargs}")
 
 
+# =============================================================================
+# BUG: Wave-timeout reported zero counters / no findings for productive members.
+# =============================================================================
+#
+# When FIRETEAM_TIMEOUT_SEC fires while a member is mid-execution, the closure-
+# local ``final_state`` inside ``_run_one`` is GC'd at cancellation, and the
+# outer timeout handler built ``_timeout_result(spec, mid, wall_s)`` which
+# hardcoded iterations_used=0, tokens_used=0 and defaulted findings=[]. Those
+# zeros were PATCHed to Postgres and propagated to the UI.
+#
+# Fix: snapshot-by-reference. ``_run_one`` registers a reference to its
+# ``final_state`` in an outer-scope ``member_snapshots`` dict; the in-place
+# ``.update(node_update)`` mutations in the astream loop keep the reference
+# current. The timeout handler reads from that map via
+# ``_timeout_result_from_snapshot`` (which reuses ``_result_from_final_state``
+# and overrides status/completion_reason).
+
+
+def _mid_flight_graph_factory(
+    *,
+    iterations_used: int = 2,
+    input_tokens: int = 1500,
+    output_tokens: int = 300,
+    findings: list | None = None,
+    delay_s: float = 5.0,
+):
+    """Member graph that yields a productive in-flight state update once,
+    then sleeps past the wave timeout. Simulates a member that did real work
+    before being cancelled by the outer wave-timeout handler."""
+    if findings is None:
+        findings = [{
+            "finding_type": "service_identified",
+            "severity": "info",
+            "title": "nginx 1.18 banner",
+            "evidence": "Server: nginx/1.18",
+            "confidence": 100,
+            "step_iteration": 1,
+        }]
+
+    class _MidFlightGraph:
+        async def _run(self, s, config=None):
+            yield {
+                "fireteam_think": {
+                    "current_iteration": iterations_used,
+                    "tokens_used": input_tokens + output_tokens,
+                    "input_tokens_used": input_tokens,
+                    "output_tokens_used": output_tokens,
+                    "chain_findings_memory": list(findings),
+                    "execution_trace": [],
+                    "target_info": {},
+                }
+            }
+            await asyncio.sleep(delay_s)
+
+        def astream(self, s, config=None):
+            return self._run(s, config)
+    return _MidFlightGraph()
+
+
+class WaveTimeoutPreservesPartialStateRegression(unittest.IsolatedAsyncioTestCase):
+    """Locks the fix: cancelled members surface real iter/token/findings
+    counts from their in-flight final_state rather than all-zeros."""
+
+    async def test_patch_body_carries_in_flight_iterations_and_tokens(self):
+        from orchestrator_helpers.nodes.fireteam_deploy_node import fireteam_deploy_node
+
+        patch_member_mock = AsyncMock()
+        with patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node._persist_deploy",
+            new=AsyncMock(return_value="id"),
+        ), patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node._patch_member",
+            new=patch_member_mock,
+        ), patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node._patch_fireteam",
+            new=AsyncMock(),
+        ), patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node.get_setting",
+            side_effect=_settings_for_timeout_test(),
+        ):
+            await fireteam_deploy_node(
+                _parent_state(n_members=1), None,
+                member_graph=_mid_flight_graph_factory(
+                    iterations_used=2,
+                    input_tokens=1500,
+                    output_tokens=300,
+                ),
+                streaming_callbacks={},
+                neo4j_creds=None,
+            )
+
+        self.assertGreater(len(patch_member_mock.call_args_list), 0,
+                           "no _patch_member calls — DB never updated")
+        last_body = patch_member_mock.call_args_list[-1].args[3]
+        self.assertEqual(last_body["status"], "timeout")
+        self.assertEqual(last_body["completionReason"], "wave_timeout")
+        self.assertEqual(
+            last_body["iterationsUsed"], 2,
+            f"expected real iterationsUsed=2 from in-flight snapshot, "
+            f"got {last_body.get('iterationsUsed')}",
+        )
+        self.assertEqual(
+            last_body["tokensUsed"], 1800,
+            f"expected real tokensUsed=1800 (1500+300), "
+            f"got {last_body.get('tokensUsed')}",
+        )
+        self.assertEqual(
+            last_body["findingsCount"], 1,
+            f"expected findingsCount=1 from in-flight chain_findings_memory, "
+            f"got {last_body.get('findingsCount')}",
+        )
+
+    def test_timeout_result_from_snapshot_with_populated_state(self):
+        """Unit test for the helper: populated snapshot → real counts +
+        timeout labels."""
+        from orchestrator_helpers.nodes.fireteam_deploy_node import (
+            _timeout_result_from_snapshot,
+        )
+
+        snapshot = {
+            "current_iteration": 3,
+            "tokens_used": 2400,
+            "input_tokens_used": 2000,
+            "output_tokens_used": 400,
+            "chain_findings_memory": [
+                {
+                    "finding_type": "configuration_found",
+                    "severity": "low",
+                    "title": "CORS wildcard",
+                    "evidence": "Access-Control-Allow-Origin: *",
+                    "confidence": 95,
+                    "step_iteration": 2,
+                },
+            ],
+            "execution_trace": [],
+            "target_info": {},
+            "parent_target_info": {},
+            "_pending_confirmation": {"tool_name": "execute_curl"},
+        }
+        spec = {"name": "Scout", "task": "t", "tools": ["curl"]}
+        result = _timeout_result_from_snapshot(snapshot, spec, "member-0-x", 30.5)
+
+        self.assertEqual(result["status"], "timeout")
+        self.assertEqual(result["completion_reason"], "wave_timeout")
+        self.assertEqual(result["iterations_used"], 3)
+        self.assertEqual(result["tokens_used"], 2400)
+        self.assertEqual(result["input_tokens_used"], 2000)
+        self.assertEqual(result["output_tokens_used"], 400)
+        self.assertEqual(len(result["findings"]), 1)
+        self.assertEqual(result["findings"][0]["title"], "CORS wildcard")
+        # pending_confirmation suppressed: member is terminating, not awaiting.
+        self.assertIsNone(result.get("pending_confirmation"))
+
+    def test_timeout_result_from_snapshot_fallback_when_no_snapshot(self):
+        """When no snapshot is registered (member cancelled before any state
+        update), fall back to the all-zeros _timeout_result."""
+        from orchestrator_helpers.nodes.fireteam_deploy_node import (
+            _timeout_result_from_snapshot,
+        )
+        result = _timeout_result_from_snapshot(None, {"name": "Scout"}, "m-0", 1.0)
+        self.assertEqual(result["status"], "timeout")
+        self.assertEqual(result["completion_reason"], "wave_timeout")
+        self.assertEqual(result["iterations_used"], 0)
+        self.assertEqual(result["tokens_used"], 0)
+        self.assertEqual(result.get("findings") or [], [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/webapp/src/app/graph/components/AIAssistantDrawer/hooks/fireteamChatState.ts
+++ b/webapp/src/app/graph/components/AIAssistantDrawer/hooks/fireteamChatState.ts
@@ -407,21 +407,32 @@ export function handleFireteamMemberCompleted(
       const authIn = Math.max(0, Number(p.input_tokens_used ?? 0))
       const authOut = Math.max(0, Number(p.output_tokens_used ?? 0))
       const authTotal = Math.max(0, Number(p.tokens_used ?? 0))
+      const authIters = Math.max(0, Number(p.iterations_used ?? 0))
+      const authFindings = Math.max(0, Number(p.findings_count ?? 0))
       // Prefer the authoritative backend totals if non-zero; fall back to the
       // per-turn accumulation we maintained via FIRETEAM_THINKING events.
+      // For iterations the live accumulator is `latest_iteration` (set per
+      // thinking event); for findings there is no live channel, so we
+      // preserve any prior non-zero value rather than overwrite to zero.
+      // This backstops a wave-timeout payload arriving with all zeros from
+      // older backends or a future regression.
       const finalIn = authIn > 0 ? authIn : (m.input_tokens_used ?? 0)
       const finalOut = authOut > 0 ? authOut : (m.output_tokens_used ?? 0)
       const finalTotal =
         authTotal > 0 ? authTotal : finalIn + finalOut || (m.tokens_used ?? 0)
+      const finalIters =
+        authIters > 0 ? authIters : (m.latest_iteration ?? m.iterations_used ?? 0)
+      const finalFindings =
+        authFindings > 0 ? authFindings : (m.findings_count ?? 0)
       return {
         ...m,
         status: p.status,
         completed_at: new Date(),
-        iterations_used: p.iterations_used,
+        iterations_used: finalIters,
         tokens_used: finalTotal,
         input_tokens_used: finalIn,
         output_tokens_used: finalOut,
-        findings_count: p.findings_count,
+        findings_count: finalFindings,
         completion_reason: undefined,
         error_message: p.error_message ?? undefined,
       }


### PR DESCRIPTION
### Summary

When a fireteam wave hit its wall-clock timeout, in-flight members were reported as `iterations_used=0, tokens_used=0, findings=[]` even when they had been doing productive work — those zeros were PATCHed to Postgres and propagated to the live UI. The fix snapshots each member's in-flight `final_state` by reference into an outer-scope map so the timeout handler can surface real counts. The UI also gets defensive `> 0 ? auth : accumulator` fallbacks for `iterations_used` and `findings_count` (matching the existing pattern for token counts).

### Problem

`agentic/orchestrator_helpers/nodes/fireteam_deploy_node.py:_timeout_result` (lines 352-361 in the original) hardcoded `iterations_used=0, tokens_used=0` and left `findings=[]` defaulted by the Pydantic model. The only place a member's in-flight state lived was the closure-local `final_state` inside `_run_one` at `:583`, mutated by `final_state.update(node_update)` during the `async for event in member_graph.astream(...)` loop at `:600-611`. On wave timeout, the outer handler called `t.cancel()` on each in-flight task; `_run_one`'s `except asyncio.CancelledError` block at `:621-627` only logged and re-raised, so `final_state` was garbage-collected. The timeout handler at `:693-703` then built `_timeout_result(spec, mid, wall_s)` from spec alone, and the `_patch_member` loop at `:709-719` PATCHed those zeros to Postgres.

Downstream: the webapp's `useConversationRestoration.ts` reload path reads those zero columns; the live UI accumulator at `webapp/src/app/graph/components/AIAssistantDrawer/hooks/fireteamChatState.ts:420,424` unconditionally overwrote `iterations_used` and `findings_count` with the zero payload from `FIRETEAM_MEMBER_COMPLETED`, so even the live UI flipped to zeros the moment the timeout event landed.

The comment at `fireteam_deploy_node.py:622-627` was misleading: it claimed the outer handler had "real iteration/token counts" — but as written, the outer handler had only `spec`, `member_id`, and `wall_s`.

### Fix

Three coordinated changes:

1. **`agentic/orchestrator_helpers/nodes/fireteam_deploy_node.py`** — Hoisted a `member_snapshots: dict = {}` map in `fireteam_deploy_node`'s scope, just before `_run_one`'s definition. Inside `_run_one`, registered the dict reference once: `member_snapshots[member_id] = final_state` immediately after `final_state = dict(member_state)`. The existing in-place `final_state.update(node_update)` calls inside the astream loop keep the registered reference current — no copy cost, no async/await coordination. Added a new helper `_timeout_result_from_snapshot(snapshot, spec, member_id, wall_s)` next to `_timeout_result`: when the snapshot is non-None it reuses `_result_from_final_state` to extract real iter/token/findings counts and then overrides `status="timeout"`, `completion_reason="wave_timeout"`, and clears `pending_confirmation` (the member is terminating, not awaiting). Falls back to the all-zeros `_timeout_result` when no snapshot exists. Replaced both `_timeout_result(...)` call sites in the wave-timeout handler with `_timeout_result_from_snapshot(member_snapshots.get(mid), ...)`. Reworded the misleading comment at the `CancelledError` branch to accurately describe the snapshot-by-reference mechanism.

2. **`webapp/src/app/graph/components/AIAssistantDrawer/hooks/fireteamChatState.ts`** — Added `> 0 ? auth : accumulator` fallbacks for `iterations_used` and `findings_count` in `handleFireteamMemberCompleted`, mirroring the existing pattern used for token counts in the same function. For iterations, the live accumulator is `m.latest_iteration` (set per `FIRETEAM_THINKING` event). For findings, there is no live channel, so the fallback preserves the previous value rather than overwriting to zero. This backstops a wave-timeout payload arriving with all zeros from older backends or a future regression.

3. **`agentic/tests/test_fireteam_regressions.py`** — Added `WaveTimeoutPreservesPartialStateRegression` with three tests: (a) an integration test using a new `_mid_flight_graph_factory` that yields a populated state update then sleeps past the wave timeout, asserting the final `_patch_member` call body carries `iterationsUsed=2`, `tokensUsed=1800`, `findingsCount=1`; (b) a unit test for `_timeout_result_from_snapshot` with a populated snapshot, asserting timeout labels override but real counts are preserved; (c) a fallback unit test confirming a `None` snapshot still produces a valid `_timeout_result` shape.

### Testing

Both static and dynamic. Three new tests added; all pass:

- `test_patch_body_carries_in_flight_iterations_and_tokens` — the integration test. With a member graph that yields `current_iteration=2, input_tokens=1500, output_tokens=300, chain_findings_memory=[...]` and then sleeps past the 1-second `FIRETEAM_TIMEOUT_SEC`, the final `_patch_member` call body asserts `iterationsUsed=2, tokensUsed=1800, findingsCount=1`. Before the fix this would have asserted zeros.
- `test_timeout_result_from_snapshot_with_populated_state` — unit test confirming the helper preserves iter/tokens/findings from a populated snapshot, overrides status to `timeout`, sets completion_reason to `wave_timeout`, and suppresses `pending_confirmation`.
- `test_timeout_result_from_snapshot_fallback_when_no_snapshot` — confirms the `None` fallback path still yields a valid all-zeros timeout result.

The four pre-existing wave-timeout regression tests (`WaveTimeoutDbPersistRegression`'s 3 tests + `WaveTimeoutWebsocketEmitRegression`'s 1 test) all still pass — no regressions.

Runtime testing with the full agent stack against a real Postgres / real webapp was impractical for the same image-bake reason noted in prior tickets — the agent container's source is COPY'd at build time, not bind-mounted, so a full `docker compose build agent` would be required before a live operator-driven repro could exercise the change. The test-based dynamic verification covers the structural contract directly.

### Risk

Low. The change is purely additive on the happy path: `member_snapshots[mid] = final_state` is a single dict assignment, and the snapshot map is only read on the wave-timeout branch. Normal completion still flows through `_result_from_final_state` unchanged. The fallback to all-zeros `_timeout_result` remains for the edge case where a member is cancelled before any state update reaches the snapshot map.

Watch-out for reviewers:
- **Cancellation safety of in-place dict mutation.** `final_state.update(node_update)` happens synchronously between `await` boundaries; there is no race window where a `dict.update()` is interrupted mid-call. Snapshot is always consistent at any `await` boundary the cancellation can fire at.
- **`pending_confirmation` is suppressed on the timeout path.** If a member was cancelled mid-await-operator-confirmation, the snapshot might still have `_pending_confirmation` set. Carrying that through would mislead the collect node into thinking the operator must still approve a wave that no longer exists. Set to None deliberately.
- **Neo4j-side findings persistence unchanged.** Findings written inline by `chain_graph_writer` during member execution were already surviving wave timeouts (the verdict's investigation confirmed this) — this PR adds preservation of the parent-state-level counters and the rolled-up findings list; it does not affect Neo4j.
- **Webapp change is defense-in-depth.** With the Python fix, payloads will carry real values; the `> 0 ?` fallback simply matches the existing token-count pattern in the same function and protects against older backends or future regressions.

No schema, API, or message-shape changes. Server-only Python plus a small client-side reducer tweak.

---