### PR TITLE
fix(fireteam): surface zero-finding waves to root planner in chain context

### DIFF
--- a/agentic/orchestrator_helpers/nodes/fireteam_collect_node.py
+++ b/agentic/orchestrator_helpers/nodes/fireteam_collect_node.py
@@ -204,6 +204,40 @@ async def fireteam_collect_node(
 
     summary = _render_summary(fireteam_id, results)
 
+    # Build a structured wave-completion entry for chain_waves_memory. Written
+    # unconditionally (even for zero-finding waves) so the next root think_node
+    # has evidence the wave ran — without this, the planner would see the same
+    # chain context a brand-new session sees and redeploy an identical plan.
+    plan_members_by_name: dict = {}
+    plan = state.get("_current_fireteam_plan") or {}
+    for spec in (plan.get("members") or []):
+        nm = (spec.get("name") or "").strip()
+        if nm:
+            plan_members_by_name[nm] = spec
+    wave_entry = {
+        "wave_id": fireteam_id,
+        "completed_at_iteration": state.get("current_iteration", 0),
+        "n_members": len(results),
+        "n_success": sum(1 for r in results if r.get("status") == "success"),
+        "n_timeout": sum(1 for r in results if r.get("status") == "timeout"),
+        "n_error":   sum(1 for r in results if r.get("status") == "error"),
+        "total_findings": findings_added,
+        "members": [
+            {
+                "name": (r.get("name") or "(unnamed)"),
+                "task_summary": (
+                    (plan_members_by_name.get((r.get("name") or "").strip(), {}).get("task") or "")
+                )[:200],
+                "status": r.get("status", "unknown"),
+                "iterations_used": int(r.get("iterations_used", 0) or 0),
+                "findings_count": len(r.get("findings") or []),
+                "completion_reason": (r.get("completion_reason") or ""),
+            }
+            for r in results
+        ],
+    }
+    chain_waves = list(state.get("chain_waves_memory") or []) + [wave_entry]
+
     # Collect every member that escalated. Per FIRETEAM.md §20 Q3, v1 surfaces
     # each one sequentially (not coalesced) so the operator decides each in
     # turn. We queue all of them now; the first drains into
@@ -248,6 +282,7 @@ async def fireteam_collect_node(
     update: dict = {
         "target_info": merged_target_info,
         "chain_findings_memory": chain_findings,
+        "chain_waves_memory": chain_waves,
         "_current_fireteam_plan": None,
         "_current_fireteam_results": None,
         "todo_list": updated_todos,

--- a/agentic/orchestrator_helpers/nodes/initialize_node.py
+++ b/agentic/orchestrator_helpers/nodes/initialize_node.py
@@ -348,6 +348,7 @@ async def initialize_node(state: AgentState, config, *, llm, neo4j_creds) -> dic
                 "chain_findings_memory": state.get("chain_findings_memory", []),
                 "chain_failures_memory": state.get("chain_failures_memory", []),
                 "chain_decisions_memory": state.get("chain_decisions_memory", []),
+                "chain_waves_memory": state.get("chain_waves_memory", []),
                 "_last_chain_step_id": state.get("_last_chain_step_id"),
                 "_prior_chain_context": state.get("_prior_chain_context"),
             }
@@ -395,6 +396,7 @@ async def initialize_node(state: AgentState, config, *, llm, neo4j_creds) -> dic
         "chain_findings_memory": state.get("chain_findings_memory", []),
         "chain_failures_memory": state.get("chain_failures_memory", []),
         "chain_decisions_memory": state.get("chain_decisions_memory", []),
+        "chain_waves_memory": state.get("chain_waves_memory", []),
         "_last_chain_step_id": state.get("_last_chain_step_id"),
         "_prior_chain_context": state.get("_prior_chain_context"),
     }

--- a/agentic/orchestrator_helpers/nodes/think_node.py
+++ b/agentic/orchestrator_helpers/nodes/think_node.py
@@ -99,6 +99,7 @@ async def think_node(state: AgentState, config, *, llm, guidance_queues, neo4j_c
         chain_failures=state.get("chain_failures_memory", []),
         chain_decisions=state.get("chain_decisions_memory", []),
         execution_trace=state.get("execution_trace", []),
+        chain_waves=state.get("chain_waves_memory", []),
     )
     todo_list_formatted = format_todo_list(state.get("todo_list", []))
     target_info_formatted = json_dumps_safe(state.get("target_info", {}), indent=2)

--- a/agentic/state.py
+++ b/agentic/state.py
@@ -714,6 +714,11 @@ class AgentState(TypedDict):
     chain_findings_memory: List[dict]    # Accumulated findings for this session
     chain_failures_memory: List[dict]    # Accumulated failures for this session
     chain_decisions_memory: List[dict]   # Accumulated decisions for this session
+    # Wave-completion history (one entry per completed fireteam wave). Written
+    # unconditionally by fireteam_collect_node — including for zero-finding
+    # waves — so the planner can see "wave X already covered scope Y" even
+    # when the wave produced no findings to attribute via source_agent tags.
+    chain_waves_memory: List[dict]
 
     # Internal: previous step ID for NEXT_STEP linking in chain graph
     _last_chain_step_id: Optional[str]
@@ -883,6 +888,7 @@ def create_initial_state(
         "chain_findings_memory": [],
         "chain_failures_memory": [],
         "chain_decisions_memory": [],
+        "chain_waves_memory": [],
         "_last_chain_step_id": None,
         "_prior_chain_context": None,
         "_response_tier": None,
@@ -1199,6 +1205,7 @@ def format_chain_context(
     chain_decisions: List[dict],
     execution_trace: List[dict],
     recent_iterations: int = 20,
+    chain_waves: Optional[List[dict]] = None,
 ) -> str:
     """Format attack chain memory for the LLM system prompt.
 
@@ -1206,8 +1213,19 @@ def format_chain_context(
     Shows the last *recent_iterations* steps with wave tools collapsed
     into a compact summary.  Findings/failures/decisions are listed up
     front for instant signal.
+
+    ``chain_waves`` lists completed fireteam waves (one entry per wave,
+    including zero-finding waves). Rendered in its own section so the planner
+    can detect "this wave already covered scope X" even when no findings were
+    attributed via source_agent.
     """
-    if not execution_trace and not chain_findings and not chain_failures:
+    chain_waves = chain_waves or []
+    if (
+        not execution_trace
+        and not chain_findings
+        and not chain_failures
+        and not chain_waves
+    ):
         return "No steps executed yet."
 
     lines: list[str] = []
@@ -1270,6 +1288,47 @@ def format_chain_context(
             approved = "approved" if d.get("approved") else "rejected"
             by = d.get("made_by") or "user"
             lines.append(f"  [step {step}] {dtype}: {from_s} → {to_s} ({by} {approved})")
+        lines.append("")
+
+    # ── Fireteam Waves ──────────────────────────────────
+    # One entry per completed fireteam wave, including zero-finding waves.
+    # The planner consults this to recognize "wave X already covered scope Y"
+    # even when no findings were attributed via source_agent tags. Without
+    # this section, a zero-finding wave leaves the planner with the same
+    # context a brand-new session sees, and the "DO NOT redeploy the same
+    # plan" directive in the system prompt has no checkable referent.
+    if chain_waves:
+        lines.append("── Fireteam Waves ────────────────────────────────")
+        for w in chain_waves:
+            wave_id = w.get("wave_id") or "?"
+            it = w.get("completed_at_iteration", "?")
+            n_members = w.get("n_members", 0)
+            n_success = w.get("n_success", 0)
+            n_timeout = w.get("n_timeout", 0)
+            n_error = w.get("n_error", 0)
+            total_findings = w.get("total_findings", 0)
+            status_parts = [f"{n_success}/{n_members} succeeded"]
+            if n_timeout:
+                status_parts.append(f"{n_timeout} timed out")
+            if n_error:
+                status_parts.append(f"{n_error} errored")
+            status_parts.append(f"{total_findings} findings")
+            lines.append(
+                f"  Wave {wave_id} [iter {it}] {', '.join(status_parts)}"
+            )
+            for m in (w.get("members") or []):
+                name = m.get("name") or "(unnamed)"
+                task = (m.get("task_summary") or "").strip()
+                status = m.get("status") or "unknown"
+                iters = m.get("iterations_used", 0)
+                f_count = m.get("findings_count", 0)
+                reason = (m.get("completion_reason") or "").strip()
+                task_str = f" — {task}" if task else ""
+                reason_str = f" — {reason}" if reason else ""
+                lines.append(
+                    f"    - {name}{task_str}: {status}, {iters} iter, "
+                    f"{f_count} findings{reason_str}"
+                )
         lines.append("")
 
     # ── Recent Steps (grouped by iteration) ─────────────


### PR DESCRIPTION
### Summary

The root planner had no signal that a fireteam wave had run when the wave produced zero findings. The four state fields rendered into `--- CHAIN CONTEXT ---` (`chain_findings_memory`, `chain_failures_memory`, `chain_decisions_memory`, `execution_trace`) are all either skipped by the fireteam-collect path or gated on non-empty findings, so a timeout / dry-hole / parse-failure wave left the planner with the same context a brand-new session sees. The next root iteration would then redeploy a near-byte-identical fireteam plan. This change adds a fifth chain-context field that the collect node writes unconditionally at wave completion, plus a rendering section in `format_chain_context` and an updated empty-state guard.

### Problem

`agentic/orchestrator_helpers/nodes/think_node.py:97-102` builds the `--- CHAIN CONTEXT ---` block from four fields — `chain_findings_memory`, `chain_failures_memory`, `chain_decisions_memory`, `execution_trace` — via `agentic/state.py:format_chain_context`. The fireteam-deploy node writes none of them. The fireteam-collect node writes only `chain_findings_memory` (`agentic/orchestrator_helpers/nodes/fireteam_collect_node.py:250`) and only by appending member-attributed entries; when no member produces a finding, the append iteration runs zero times and the field stays empty.

When all four fields are empty, `format_chain_context` at `agentic/state.py:1210-1211` hits its empty-state branch and returns the literal string `"No steps executed yet."` The root's next `think_node` invocation then sees the same chain context a freshly-started session would see. The system-prompt directive at `agentic/prompts/base.py:115-119` ("DO NOT redeploy the same plan") references "(from <specialist>) tags on findings in chain context" — a check the LLM is structurally unable to perform on the zero-finding path, because no findings exist to carry the tags.

The collect node also pushes a `SystemMessage(content=summary)` into `state["messages"]` at `fireteam_collect_node.py:254`, but `think_node`'s LLM payload at `:449-452` is just `[SystemMessage(system_prompt), HumanMessage(...)]` — `state.messages` is never consumed.

Combined effect: a wave that legitimately produces zero findings (timeout, error, real dry hole, or — until other fixes land — a productive wave whose findings get dropped by other code paths) leaves the planner blind to its existence. Empirically, this manifests as the planner redeploying the same fireteam plan one think turn after a 1-hour timeout.

### Fix

Four files modified:

1. **`agentic/state.py`** — Added a fifth chain-context field `chain_waves_memory: List[dict]` to the `AgentState` TypedDict (next to the other chain memory fields), initialized to `[]` in the session-init dict. Extended `format_chain_context` with a keyword-only `chain_waves: Optional[List[dict]] = None` parameter (coalesced to `[]`). Updated the empty-state guard so a non-empty `chain_waves` bypasses the `"No steps executed yet."` fallback. Added a new "── Fireteam Waves ──" rendering section, placed between "── Decisions ──" and "── Recent Steps ──". Each wave entry renders as a header line with wave_id, completed_at_iteration, success/timeout/error counts, and total_findings, followed by per-member lines with name, task_summary, status, iterations_used, findings_count, and completion_reason.

2. **`agentic/orchestrator_helpers/nodes/initialize_node.py`** — Added `chain_waves_memory` passthrough to both resume paths (the new-objective branch around line 350 and the continue-current-objective branch around line 396), each reading `state.get("chain_waves_memory", [])`.

3. **`agentic/orchestrator_helpers/nodes/think_node.py`** — Passes `chain_waves=state.get("chain_waves_memory", [])` to `format_chain_context` in the prompt-building block (around line 97).

4. **`agentic/orchestrator_helpers/nodes/fireteam_collect_node.py`** — Built a structured `wave_entry` dict at wave completion (after the existing `_render_summary` call) from the `results` list and the `_current_fireteam_plan` member specs. Task summaries are looked up by name from the plan spec and truncated to 200 chars. Computed `chain_waves = list(state.get("chain_waves_memory") or []) + [wave_entry]` and added it to the update dict as `"chain_waves_memory": chain_waves`. **Unconditional write** — runs regardless of `findings_added`, which is the load-bearing semantic: zero-finding waves must produce an entry too.

The wave-entry shape:

```python
{
    "wave_id": fireteam_id,
    "completed_at_iteration": state.get("current_iteration", 0),
    "n_members": int, "n_success": int, "n_timeout": int, "n_error": int,
    "total_findings": int,
    "members": [
        {"name": str, "task_summary": str (≤200 chars),
         "status": str, "iterations_used": int,
         "findings_count": int, "completion_reason": str},
        ...
    ],
}
```

The new `format_chain_context` parameter is keyword-only with a `None` default. The existing positional call sites in `fireteam_member_think_node.py:625,637` and the kwargs call in `tests/test_fireteam_core.py:270` continue to work without changes — they simply don't render the new section, which is correct (members don't decide deploys).

### Testing

Static verification only. Runtime testing was impractical for two compounding reasons: (a) triggering the bug requires a fireteam wave that legitimately finds nothing (e.g., nuclei against an empty target), which is a hands-on operator-driven repro through the webapp UI rather than a scripted reproduction, and (b) the agent container image bakes `agentic/` via Dockerfile COPY rather than bind-mount, so a `docker compose build agent` is required before runtime testing can exercise the change.

Static verification covered:

1. Module-parse: `python -c "import ast; ast.parse(open(...).read())"` for all four modified files — all OK.
2. Trace through the zero-finding-wave path: collect builds `wave_entry` unconditionally → update dict sets `chain_waves_memory` → next think_node passes it to `format_chain_context` → empty-state guard now sees `chain_waves != []` → bypasses `"No steps executed yet."` → renders "── Fireteam Waves ──" section with wave header + member entries.
3. Trace through the productive-wave path: findings section renders source_agent attribution as before; waves section additionally renders the wave summary. Both signals available to the planner.
4. Backward-compat trace for `format_chain_context` call sites: tests + member-think-node use positional args without `chain_waves` → default `None` → coalesced to `[]` → renderer skips the new section. No behavioural change for existing callers.
5. Backward-compat trace for resume / checkpoint loading: a pre-fix checkpoint won't have `chain_waves_memory` in state. `state.get("chain_waves_memory", [])` returns `[]`. No crash.

### Risk

Low. The change is purely additive — new state field with `[]` default, new optional parameter, new rendering section. Existing call sites do not need updates. The empty-state guard now allows a single wave entry to bypass `"No steps executed yet."`, which is the load-bearing behaviour; reviewers should confirm that's the intended semantic (rather than e.g. "treat a zero-finding wave the same as no wave" — which is the buggy behavior this PR removes).

Watch-out for reviewers:
- The wave entry's `task_summary` is sourced from `_current_fireteam_plan.members[*].task` and truncated to 200 chars. If the plan structure is `None` or shaped differently for some edge case (e.g. a wave bypassing the plan-deploy flow), the lookup falls back to empty string. Verify the lookup is robust against plan-shape variation.
- The new field is independent of `chain_findings_memory`. If chain_findings were already non-empty before the wave ran, the empty-state guard wouldn't have fired anyway — so this change is a strict superset of prior chain-context content; it never hides existing signal.
- Context-size impact: each wave entry is small (~hundreds of chars including member lines). Over a long session with many waves, this could grow. Not a concern at typical session lengths.

Server-only Python; no schema, API, or message-shape changes.

---