### PR TITLE
fix(mcp): network recon wrappers distinguish success-no-match from tool failure

### DIFF
--- a/mcp/servers/network_recon_server.py
+++ b/mcp/servers/network_recon_server.py
@@ -36,6 +36,56 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 # Strip ANSI escape codes (terminal colors) from output
 ANSI_ESCAPE = re.compile(r'\x1b\[[0-9;]*[a-zA-Z]')
 
+
+def _format_subprocess_result(
+    result: subprocess.CompletedProcess,
+    *,
+    tool_name: str,
+    no_match_msg: str,
+    stderr_filter=None,
+) -> str:
+    """Build a wrapper return string that distinguishes success-with-no-match
+    from tool failure based on result.returncode.
+
+    The previous shape (`return output if output.strip() else "[INFO] ..."`
+    without inspecting returncode) conflated three different outcomes:
+    success-no-match, per-host timeout, and silent tool failure. The agent
+    then mis-classified live targets as dead. This helper centralises the
+    three-way contract every wrapper needs:
+
+    - returncode != 0: "[ERROR] {tool_name} failed: returncode=N, stderr=..."
+      The trimmed stderr is included so the LLM has context to decide
+      retry-vs-give-up (e.g. DNS resolution failed vs binary missing).
+    - returncode == 0 and stdout empty after stripping: no_match_msg.
+    - returncode == 0 and stdout has content: the stdout (with any kept
+      stderr lines appended via the existing "[STDERR]: ..." convention).
+
+    Args:
+        result: Output of subprocess.run.
+        tool_name: Name surfaced in error strings (e.g. "execute_httpx").
+        no_match_msg: Informational string for the legitimate-no-match case.
+        stderr_filter: Optional predicate(line) -> bool; True keeps the line.
+                       ANSI codes are stripped before filtering. Default keeps
+                       all non-empty lines.
+    """
+    clean_stdout = ANSI_ESCAPE.sub('', result.stdout or '')
+    clean_stderr = ANSI_ESCAPE.sub('', result.stderr or '')
+    if stderr_filter is None:
+        stderr_filter = lambda line: bool(line)
+    kept_stderr = [line for line in clean_stderr.split('\n') if stderr_filter(line)]
+
+    if result.returncode != 0:
+        stderr_trim = '\n'.join(kept_stderr)[:2000]
+        msg = f"[ERROR] {tool_name} failed: returncode={result.returncode}"
+        if stderr_trim:
+            msg += f", stderr={stderr_trim}"
+        return msg
+
+    output = clean_stdout
+    if kept_stderr:
+        output += f"\n[STDERR]: {chr(10).join(kept_stderr)}"
+    return output if output.strip() else no_match_msg
+
 # Server configuration
 SERVER_NAME = "network_recon"
 SERVER_HOST = os.getenv("MCP_HOST", "0.0.0.0")
@@ -117,10 +167,11 @@ def execute_curl(args: str) -> str:
             text=True,
             timeout=60
         )
-        output = result.stdout
-        if result.stderr:
-            output += f"\n[STDERR]: {result.stderr}"
-        return output if output.strip() else "[INFO] No response received"
+        return _format_subprocess_result(
+            result,
+            tool_name="execute_curl",
+            no_match_msg="[INFO] No response received",
+        )
     except subprocess.TimeoutExpired:
         return "[ERROR] Command timed out after 60 seconds. Consider using --connect-timeout and --max-time flags."
     except FileNotFoundError:
@@ -171,17 +222,12 @@ def execute_naabu(args: str) -> str:
             text=True,
             timeout=300
         )
-        output = ANSI_ESCAPE.sub('', result.stdout)
-        if result.stderr:
-            # Strip ANSI codes then filter out progress/info messages, keep errors
-            clean_stderr = ANSI_ESCAPE.sub('', result.stderr)
-            stderr_lines = [
-                line for line in clean_stderr.split('\n')
-                if line and not line.startswith('[INF]')
-            ]
-            if stderr_lines:
-                output += f"\n[STDERR]: {chr(10).join(stderr_lines)}"
-        return output if output.strip() else "[INFO] No open ports found"
+        return _format_subprocess_result(
+            result,
+            tool_name="execute_naabu",
+            no_match_msg="[INFO] No open ports found",
+            stderr_filter=lambda l: bool(l) and not l.startswith('[INF]'),
+        )
     except subprocess.TimeoutExpired:
         return "[ERROR] Command timed out after 300 seconds. Consider using a smaller port range or higher rate."
     except FileNotFoundError:
@@ -235,16 +281,12 @@ def execute_httpx(args: str) -> str:
             text=True,
             timeout=300
         )
-        output = ANSI_ESCAPE.sub('', result.stdout)
-        if result.stderr:
-            clean_stderr = ANSI_ESCAPE.sub('', result.stderr)
-            stderr_lines = [
-                line for line in clean_stderr.split('\n')
-                if line and not line.startswith('[INF]')
-            ]
-            if stderr_lines:
-                output += f"\n[STDERR]: {chr(10).join(stderr_lines)}"
-        return output if output.strip() else "[INFO] No live hosts found"
+        return _format_subprocess_result(
+            result,
+            tool_name="execute_httpx",
+            no_match_msg="[INFO] No live hosts found",
+            stderr_filter=lambda l: bool(l) and not l.startswith('[INF]'),
+        )
     except subprocess.TimeoutExpired:
         return "[ERROR] Command timed out after 300 seconds. Consider using fewer targets or adding -timeout flag."
     except FileNotFoundError:
@@ -302,16 +344,12 @@ def execute_subfinder(args: str) -> str:
             text=True,
             timeout=120
         )
-        output = ANSI_ESCAPE.sub('', result.stdout)
-        if result.stderr:
-            clean_stderr = ANSI_ESCAPE.sub('', result.stderr)
-            stderr_lines = [
-                line for line in clean_stderr.split('\n')
-                if line and not line.startswith('[INF]')
-            ]
-            if stderr_lines:
-                output += f"\n[STDERR]: {chr(10).join(stderr_lines)}"
-        return output if output.strip() else "[INFO] No subdomains found"
+        return _format_subprocess_result(
+            result,
+            tool_name="execute_subfinder",
+            no_match_msg="[INFO] No subdomains found",
+            stderr_filter=lambda l: bool(l) and not l.startswith('[INF]'),
+        )
     except subprocess.TimeoutExpired:
         return "[ERROR] Command timed out after 120 seconds. Consider using -timeout flag to limit per-source timeout."
     except FileNotFoundError:
@@ -378,18 +416,16 @@ def execute_gau(args: str, urlscan_api_key: str = "") -> str:
             text=True,
             timeout=300
         )
-        output = ANSI_ESCAPE.sub('', result.stdout)
-        if result.stderr:
-            clean_stderr = ANSI_ESCAPE.sub('', result.stderr)
-            stderr_lines = [
-                line for line in clean_stderr.split('\n')
-                if line
-                and not line.startswith('[INF]')
-                and 'using default config' not in line
-            ]
-            if stderr_lines:
-                output += f"\n[STDERR]: {chr(10).join(stderr_lines)}"
-        return output if output.strip() else "[INFO] No URLs found in archives for this domain"
+        return _format_subprocess_result(
+            result,
+            tool_name="execute_gau",
+            no_match_msg="[INFO] No URLs found in archives for this domain",
+            stderr_filter=lambda l: (
+                bool(l)
+                and not l.startswith('[INF]')
+                and 'using default config' not in l
+            ),
+        )
     except subprocess.TimeoutExpired:
         return "[ERROR] Command timed out after 300 seconds. Consider using --blacklist to filter extensions or --providers to limit sources."
     except FileNotFoundError:
@@ -439,10 +475,11 @@ def kali_shell(command: str) -> str:
             text=True,
             timeout=300
         )
-        output = result.stdout
-        if result.stderr:
-            output += f"\n[STDERR]: {result.stderr}"
-        return output if output.strip() else "[INFO] Command completed with no output"
+        return _format_subprocess_result(
+            result,
+            tool_name="kali_shell",
+            no_match_msg="[INFO] Command completed with no output",
+        )
     except subprocess.TimeoutExpired:
         return "[ERROR] Command timed out after 300 seconds."
     except Exception as e:
@@ -659,6 +696,21 @@ def execute_hydra(args: str) -> str:
             _hydra_active = False
 
         output = '\n'.join(output_lines)
+        # Distinguish a clean run (returncode 0) that found no creds from a
+        # hydra-level failure (e.g. unsupported service, bad target). Hydra's
+        # stderr was merged into stdout above, so any error context is already
+        # in `output`. We only synthesize an [ERROR] envelope on non-zero exit
+        # AND empty/uninformative output — when output is rich (e.g. it has a
+        # hydra panic message) the LLM can read it directly.
+        if proc.returncode != 0 and not output.strip():
+            return (
+                f"[ERROR] execute_hydra failed: returncode={proc.returncode} "
+                f"(no output captured; check target/protocol/credentials list)"
+            )
+        if proc.returncode != 0 and output.strip():
+            # Surface non-zero exit even when output is present, so the LLM
+            # doesn't mistake a partial-failure dump for a clean negative.
+            return f"[ERROR] execute_hydra failed: returncode={proc.returncode}\n{output}"
         return output if output.strip() else "[INFO] No valid credentials found"
 
     except FileNotFoundError:
@@ -713,16 +765,12 @@ def execute_jsluice(args: str) -> str:
             text=True,
             timeout=120
         )
-        output = result.stdout
-        if result.stderr:
-            clean_stderr = ANSI_ESCAPE.sub('', result.stderr)
-            stderr_lines = [
-                line for line in clean_stderr.split('\n')
-                if line.strip()
-            ]
-            if stderr_lines:
-                output += f"\n[STDERR]: {chr(10).join(stderr_lines)}"
-        return output if output.strip() else "[INFO] No results found in the analyzed files"
+        return _format_subprocess_result(
+            result,
+            tool_name="execute_jsluice",
+            no_match_msg="[INFO] No results found in the analyzed files",
+            stderr_filter=lambda l: bool(l.strip()),
+        )
     except subprocess.TimeoutExpired:
         return "[ERROR] Command timed out after 120 seconds."
     except FileNotFoundError:
@@ -782,17 +830,12 @@ def execute_masscan(args: str) -> str:
             text=True,
             timeout=600
         )
-
-        output = ""
-        if result.stdout:
-            output += result.stdout
-        if result.stderr:
-            stderr_lines = result.stderr.strip().split('\n')
-            useful_stderr = [l for l in stderr_lines if not l.startswith('rate:')]
-            if useful_stderr:
-                output += "\n[STDERR]\n" + "\n".join(useful_stderr)
-
-        return output.strip() if output.strip() else "[INFO] Scan completed with no output."
+        return _format_subprocess_result(
+            result,
+            tool_name="execute_masscan",
+            no_match_msg="[INFO] Scan completed with no output.",
+            stderr_filter=lambda l: bool(l) and not l.startswith('rate:'),
+        )
 
     except subprocess.TimeoutExpired:
         return "[ERROR] Command timed out after 600 seconds. Use smaller target ranges or fewer ports."
@@ -838,23 +881,16 @@ def execute_wpscan(args: str) -> str:
             text=True,
             timeout=600
         )
-
-        output = ""
-        if result.stdout:
-            output += ANSI_ESCAPE.sub('', result.stdout)
-        if result.stderr:
-            clean_stderr = ANSI_ESCAPE.sub('', result.stderr)
-            stderr_lines = [
-                line for line in clean_stderr.split('\n')
-                if line and not line.startswith('[i]') and 'warning:' not in line.lower()
-            ]
-            if stderr_lines:
-                output += f"\n[STDERR]: {chr(10).join(stderr_lines)}"
-
-        if not output.strip():
-            return "[INFO] WPScan completed with no output. Target may not be a WordPress site."
-
-        return output
+        return _format_subprocess_result(
+            result,
+            tool_name="execute_wpscan",
+            no_match_msg="[INFO] WPScan completed with no output. Target may not be a WordPress site.",
+            stderr_filter=lambda l: (
+                bool(l)
+                and not l.startswith('[i]')
+                and 'warning:' not in l.lower()
+            ),
+        )
 
     except subprocess.TimeoutExpired:
         return "[ERROR] WPScan timed out after 600 seconds."
@@ -908,24 +944,16 @@ def execute_amass(args: str) -> str:
             text=True,
             timeout=1800  # 30 min hard limit — passive+active enum on real domains often needs 15-25 min
         )
-
-        output = ""
-        if result.stdout:
-            output += ANSI_ESCAPE.sub('', result.stdout)
-        if result.stderr:
-            clean_stderr = ANSI_ESCAPE.sub('', result.stderr)
-            stderr_lines = [
-                line for line in clean_stderr.split('\n')
-                if line and not line.startswith('Querying ')
-                and not line.startswith('[INF]')
-            ]
-            if stderr_lines:
-                output += f"\n[STDERR]: {chr(10).join(stderr_lines)}"
-
-        if not output.strip():
-            return "[INFO] Amass completed with no output. No subdomains found for the target."
-
-        return output
+        return _format_subprocess_result(
+            result,
+            tool_name="execute_amass",
+            no_match_msg="[INFO] Amass completed with no output. No subdomains found for the target.",
+            stderr_filter=lambda l: (
+                bool(l)
+                and not l.startswith('Querying ')
+                and not l.startswith('[INF]')
+            ),
+        )
 
     except subprocess.TimeoutExpired:
         return "[ERROR] Amass timed out after 660 seconds. Use -timeout flag to set a shorter amass timeout."
@@ -979,25 +1007,16 @@ def execute_katana(args: str) -> str:
             text=True,
             timeout=1800  # 30 min -- depth=2 + JS crawling on real sites routinely exceeds 10 min
         )
-
-        output = ""
-        if result.stdout:
-            output += ANSI_ESCAPE.sub('', result.stdout)
-        if result.stderr:
-            clean_stderr = ANSI_ESCAPE.sub('', result.stderr)
-            stderr_lines = [
-                line for line in clean_stderr.split('\n')
-                if line.strip()
-                and not line.startswith('[INF]')
-                and not line.startswith('[WRN]')
-            ]
-            if stderr_lines:
-                output += f"\n[STDERR]: {chr(10).join(stderr_lines)}"
-
-        if not output.strip():
-            return "[INFO] Katana completed with no output. No URLs/endpoints discovered for the target."
-
-        return output
+        return _format_subprocess_result(
+            result,
+            tool_name="execute_katana",
+            no_match_msg="[INFO] Katana completed with no output. No URLs/endpoints discovered for the target.",
+            stderr_filter=lambda l: (
+                bool(l.strip())
+                and not l.startswith('[INF]')
+                and not l.startswith('[WRN]')
+            ),
+        )
 
     except subprocess.TimeoutExpired:
         return "[ERROR] Katana timed out after 600 seconds. Consider reducing -d (depth), lowering -c (concurrency), or narrowing scope."
@@ -1054,18 +1073,23 @@ def execute_arjun(args: str) -> str:
             text=True,
             timeout=1200
         )
+        # arjun has post-processing (reads -oJ JSON output file), so we can't
+        # use _format_subprocess_result directly. Do the returncode-aware
+        # error path inline, then build the success-path output with the
+        # JSON file injection.
+        stderr_filter = lambda l: bool(l.strip()) and not l.strip().startswith('[*]')
+        clean_stderr_raw = ANSI_ESCAPE.sub('', result.stderr or '')
+        kept_stderr = [l for l in clean_stderr_raw.split('\n') if stderr_filter(l)]
+        if result.returncode != 0:
+            stderr_trim = '\n'.join(kept_stderr)[:2000]
+            msg = f"[ERROR] execute_arjun failed: returncode={result.returncode}"
+            if stderr_trim:
+                msg += f", stderr={stderr_trim}"
+            return msg
 
-        output = ""
-        if result.stdout:
-            output += ANSI_ESCAPE.sub('', result.stdout)
-        if result.stderr:
-            clean_stderr = ANSI_ESCAPE.sub('', result.stderr)
-            stderr_lines = [
-                line for line in clean_stderr.split('\n')
-                if line.strip() and not line.strip().startswith('[*]')
-            ]
-            if stderr_lines:
-                output += f"\n[STDERR]: {chr(10).join(stderr_lines)}"
+        output = ANSI_ESCAPE.sub('', result.stdout or '')
+        if kept_stderr:
+            output += f"\n[STDERR]: {chr(10).join(kept_stderr)}"
 
         # Arjun writes JSON results to file (not stdout). Auto-read if -oJ was used.
         for i, arg in enumerate(cmd_args):
@@ -1148,31 +1172,22 @@ def execute_ffuf(args: str) -> str:
             text=True,
             timeout=1200
         )
-
-        output = ""
-        if result.stdout:
-            output += ANSI_ESCAPE.sub('', result.stdout)
-        if result.stderr:
-            clean_stderr = ANSI_ESCAPE.sub('', result.stderr)
-            stderr_lines = [
-                line for line in clean_stderr.split('\n')
-                if line.strip()
-                and not line.strip().startswith(':: ')
-                and 'progress:' not in line.lower()
-                and 'job #' not in line.lower()
-                and '___' not in line
-                and '\\/' not in line
-                and '/\\' not in line
-                and line.strip() not in ('', '_' * 48)
-                and not line.strip().startswith('v2.')
-            ]
-            if stderr_lines:
-                output += f"\n[STDERR]: {chr(10).join(stderr_lines)}"
-
-        if not output.strip():
-            return "[INFO] No results found matching the specified filters."
-
-        return output
+        return _format_subprocess_result(
+            result,
+            tool_name="execute_ffuf",
+            no_match_msg="[INFO] No results found matching the specified filters.",
+            stderr_filter=lambda l: (
+                bool(l.strip())
+                and not l.strip().startswith(':: ')
+                and 'progress:' not in l.lower()
+                and 'job #' not in l.lower()
+                and '___' not in l
+                and '\\/' not in l
+                and '/\\' not in l
+                and l.strip() not in ('', '_' * 48)
+                and not l.strip().startswith('v2.')
+            ),
+        )
 
     except subprocess.TimeoutExpired:
         return "[ERROR] FFuf timed out after 600 seconds. Consider narrowing scope with -mc/-fc/-fs filters or a smaller wordlist."
@@ -1257,19 +1272,17 @@ def cve_intel(args: str, api_key: str = "") -> str:
             timeout=60,
             env=env,
         )
-        output = ANSI_ESCAPE.sub('', result.stdout)
-        if result.stderr:
-            clean_stderr = ANSI_ESCAPE.sub('', result.stderr)
-            stderr_lines = [
-                line for line in clean_stderr.split('\n')
-                if line
-                and not line.startswith('[INF]')
-                and 'Current vulnx version' not in line
-                and 'using default config' not in line
-            ]
-            if stderr_lines:
-                output += f"\n[STDERR]: {chr(10).join(stderr_lines)}"
-        return output if output.strip() else "[INFO] No CVEs matched the query"
+        return _format_subprocess_result(
+            result,
+            tool_name="cve_intel",
+            no_match_msg="[INFO] No CVEs matched the query",
+            stderr_filter=lambda l: (
+                bool(l)
+                and not l.startswith('[INF]')
+                and 'Current vulnx version' not in l
+                and 'using default config' not in l
+            ),
+        )
     except subprocess.TimeoutExpired:
         return "[ERROR] vulnx timed out after 60 seconds. Tighten the query (add --limit, narrow filters)."
     except FileNotFoundError:

--- a/mcp/tests/test_network_recon_wrapper_format.py
+++ b/mcp/tests/test_network_recon_wrapper_format.py
@@ -1,0 +1,168 @@
+"""Tests for the network_recon_server output-formatting contract.
+
+Pins the FAPP-48 fix: wrappers must distinguish success-with-no-match from
+tool failure based on `result.returncode`, rather than collapsing both into
+the same "[INFO] No <thing> found" string when stdout happens to be empty.
+
+The helper `_format_subprocess_result` encodes the contract once for the 13
+wrappers that subprocess.run-shape; these tests exercise that helper directly.
+
+Run:
+    python -m unittest mcp.tests.test_network_recon_wrapper_format -v
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from subprocess import CompletedProcess
+
+# Import the helper. The MCP server module lives one dir up from tests/.
+_mcp_servers_dir = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "servers",
+)
+sys.path.insert(0, _mcp_servers_dir)
+
+from network_recon_server import _format_subprocess_result  # noqa: E402
+
+
+def _mk(returncode: int, stdout: str = "", stderr: str = "") -> CompletedProcess:
+    """Build a CompletedProcess for tests without invoking a real subprocess."""
+    return CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+class FormatSubprocessResultTests(unittest.TestCase):
+    """Pins the three-way contract: success-with-content / success-no-match /
+    failure are surfaced as distinguishable strings."""
+
+    def test_success_with_content_returns_stdout(self):
+        result = _mk(0, stdout='{"host": "example.com", "status_code": 200}\n')
+        out = _format_subprocess_result(
+            result, tool_name="execute_httpx",
+            no_match_msg="[INFO] No live hosts found",
+        )
+        self.assertIn("example.com", out)
+        self.assertIn("200", out)
+        self.assertNotIn("No live hosts found", out)
+        self.assertNotIn("[ERROR]", out)
+
+    def test_success_with_empty_stdout_returns_no_match_msg(self):
+        result = _mk(0, stdout="", stderr="[INF] Sending requests to 1 targets\n")
+        out = _format_subprocess_result(
+            result, tool_name="execute_httpx",
+            no_match_msg="[INFO] No live hosts found",
+            stderr_filter=lambda l: bool(l) and not l.startswith('[INF]'),
+        )
+        self.assertEqual(out, "[INFO] No live hosts found")
+
+    def test_failure_returncode_surfaces_error_with_returncode(self):
+        """The load-bearing assertion. Pre-fix this would have returned the
+        same no_match_msg as the legit no-match case, hiding the failure."""
+        result = _mk(
+            1, stdout="",
+            stderr="httpx: error: invalid target syntax 'not-a-url'\n",
+        )
+        out = _format_subprocess_result(
+            result, tool_name="execute_httpx",
+            no_match_msg="[INFO] No live hosts found",
+            stderr_filter=lambda l: bool(l) and not l.startswith('[INF]'),
+        )
+        self.assertIn("[ERROR]", out)
+        self.assertIn("execute_httpx", out)
+        self.assertIn("returncode=1", out)
+        self.assertIn("invalid target syntax", out)
+        self.assertNotIn("No live hosts found", out)
+
+    def test_failure_returncode_with_no_stderr(self):
+        """Subprocess died silently with no useful stderr — still surface the
+        returncode so the LLM doesn't trust an empty payload."""
+        result = _mk(139, stdout="", stderr="")
+        out = _format_subprocess_result(
+            result, tool_name="execute_naabu",
+            no_match_msg="[INFO] No open ports found",
+        )
+        self.assertIn("[ERROR]", out)
+        self.assertIn("execute_naabu", out)
+        self.assertIn("returncode=139", out)
+        # No stderr trim should appear when stderr was empty.
+        self.assertNotIn("stderr=", out)
+
+    def test_stderr_filter_keeps_only_non_info_lines(self):
+        """Filter callable is applied to stderr before deciding what to keep
+        and (on success) what to append to stdout."""
+        result = _mk(
+            0, stdout="200 http://example.com\n",
+            stderr="[INF] Targets loaded: 1\n[ERR] TLS handshake aborted\n",
+        )
+        out = _format_subprocess_result(
+            result, tool_name="execute_httpx",
+            no_match_msg="[INFO] No live hosts found",
+            stderr_filter=lambda l: bool(l) and not l.startswith('[INF]'),
+        )
+        self.assertIn("200 http://example.com", out)
+        self.assertIn("[STDERR]", out)
+        self.assertIn("TLS handshake aborted", out)
+        self.assertNotIn("Targets loaded", out)  # [INF] filtered out
+
+    def test_failure_with_filtered_stderr_includes_kept_lines(self):
+        """When the run fails, the error string should include only the
+        filter-kept stderr (LLM doesn't need to see noise)."""
+        result = _mk(
+            2, stdout="",
+            stderr=(
+                "[INF] Loading targets\n"
+                "[ERR] cannot resolve example.invalid: NXDOMAIN\n"
+                "[INF] Closing\n"
+            ),
+        )
+        out = _format_subprocess_result(
+            result, tool_name="execute_httpx",
+            no_match_msg="[INFO] No live hosts found",
+            stderr_filter=lambda l: bool(l) and not l.startswith('[INF]'),
+        )
+        self.assertIn("[ERROR]", out)
+        self.assertIn("returncode=2", out)
+        self.assertIn("NXDOMAIN", out)
+        self.assertNotIn("Loading targets", out)
+        self.assertNotIn("Closing", out)
+
+    def test_ansi_codes_stripped_from_both_streams(self):
+        result = _mk(
+            0,
+            stdout="\x1b[32m200\x1b[0m http://example.com\n",
+            stderr="\x1b[31m[ERR]\x1b[0m something\n",
+        )
+        out = _format_subprocess_result(
+            result, tool_name="execute_httpx",
+            no_match_msg="[INFO] No live hosts found",
+        )
+        self.assertIn("200 http://example.com", out)
+        self.assertNotIn("\x1b[", out)
+
+    def test_default_stderr_filter_keeps_non_empty(self):
+        result = _mk(0, stdout="ok", stderr="warn1\n\nwarn2\n")
+        out = _format_subprocess_result(
+            result, tool_name="kali_shell",
+            no_match_msg="[INFO] Command completed with no output",
+        )
+        self.assertIn("warn1", out)
+        self.assertIn("warn2", out)
+
+    def test_long_stderr_trimmed_to_2000_chars_in_error_path(self):
+        long_stderr = "panic\n" + ("x" * 5000)
+        result = _mk(1, stdout="", stderr=long_stderr)
+        out = _format_subprocess_result(
+            result, tool_name="execute_curl",
+            no_match_msg="[INFO] No response received",
+        )
+        self.assertIn("[ERROR]", out)
+        self.assertIn("returncode=1", out)
+        # Trim cap is 2000 chars after the "stderr=" label.
+        stderr_section = out.split("stderr=", 1)[1] if "stderr=" in out else ""
+        self.assertLessEqual(len(stderr_section), 2000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

The MCP network-recon tool wrappers returned the same `"[INFO] No <thing> found"` string when the underlying tool succeeded with no matches AND when it failed silently (per-host timeout, DNS resolution failure, connection refused, panic). Because every wrapper used `return output if output.strip() else "[INFO] ..."` without inspecting `result.returncode`, the agent received an identical "negative result" for genuinely-no-match and for tool-failed-quietly cases — and then misclassified live targets as dead. The fix introduces one helper that encodes the three-way contract (success-with-content / success-no-match / failure) and migrates 13 wrappers + one special-case wrapper to use it. A regression-test module pins the contract.

### Problem

`mcp/servers/network_recon_server.py` had 15 tool wrappers. 14 of them (every one except `execute_code`) shared the pattern:

```python
result = subprocess.run([tool] + cmd_args, capture_output=True, text=True, ...)
output = ANSI_ESCAPE.sub('', result.stdout)
if result.stderr:
    clean_stderr = ANSI_ESCAPE.sub('', result.stderr)
    stderr_lines = [l for l in clean_stderr.split('\n') if l and not l.startswith('[INF]')]
    if stderr_lines:
        output += f"\n[STDERR]: {chr(10).join(stderr_lines)}"
return output if output.strip() else "[INFO] No <thing> found"
```

`result.returncode` was never inspected. Combined with `[INF]`-prefix stripping (or equivalent filters in other wrappers), httpx's most common per-host failure modes — DNS failure, connection refused, per-host timeout, TLS error — all produce empty stdout + `[INF]`-only stderr, and therefore returned the literal `"[INFO] No live hosts found"` string. The downstream LLM was told the target was "not live" when in reality the tool had hit a transient network failure.

Concrete example from the wider audit: `execute_httpx -u http://44.228.249.3` returned `"[INFO] No live hosts found"` inside a wave where `nuclei` was simultaneously scanning the same host successfully — i.e. the host was provably alive; httpx had silently failed and the wrapper had reported the failure using "no live hosts found" semantics. Five similar instances were observed in the same run.

The same anti-pattern was present in `execute_curl` (`:112-129`), `execute_naabu` (`:166-190`), `execute_httpx` (`:230-253`), `execute_subfinder` (`:297-320`), `execute_gau` (`:367-398`), `kali_shell` (`:435-449`), `execute_hydra` (`:619-671`, Popen-based variant), `execute_jsluice` (`:708-731`), `execute_masscan` (`:777-802`), `execute_wpscan` (`:833-864`), `execute_amass` (`:903-935`), `execute_katana` (`:969-1007`), `execute_arjun` (`:1049-1092`), `execute_ffuf` (`:1138-1182`), `cve_intel` (`:1248-1278`). Only `execute_code` already inspected `returncode` (`:564`).

### Fix

`mcp/servers/network_recon_server.py`:

1. Added a `_format_subprocess_result(result, *, tool_name, no_match_msg, stderr_filter=None)` helper. It centralises the three-way contract every wrapper needs:
   - `returncode != 0` → `"[ERROR] {tool_name} failed: returncode=N, stderr=<filtered, trimmed to 2000 chars>"`.
   - `returncode == 0` and `stdout` empty after stripping → `no_match_msg`.
   - `returncode == 0` and stdout has content → the stdout (with kept stderr lines appended via the existing `\n[STDERR]: ...` convention).
   The `stderr_filter` is a callable so each wrapper can encode its own informational-line rules (e.g., httpx/naabu strip `[INF]`; ffuf strips banner art and progress lines; arjun strips `[*]`; wpscan strips `[i]` and `warning:`).
2. Migrated 13 wrappers to use the helper: `execute_curl`, `execute_naabu`, `execute_httpx`, `execute_subfinder`, `execute_gau`, `kali_shell`, `execute_jsluice`, `execute_masscan`, `execute_wpscan`, `execute_amass`, `execute_katana`, `execute_ffuf`, `cve_intel`.
3. `execute_arjun` was handled inline rather than via the helper: it has post-processing (it reads a `-oJ` JSON output file after the subprocess returns) that the helper's flat success-path doesn't support cleanly. The returncode-aware error path is identical in shape to the helper; the success path replicates the helper's output-building then appends the JSON file injection as before.
4. `execute_hydra` was special-cased because it uses `subprocess.Popen` with streaming output and merged stderr, not `subprocess.run`. Added a `proc.returncode != 0` check that surfaces `"[ERROR] execute_hydra failed: returncode=N"` either standalone (empty output) or wrapping the captured output (non-empty), so a hydra-level failure no longer looks like a clean negative result.
5. `execute_code` was deliberately left untouched: it already inspected `result.returncode` at its existing line 564 and has a more complex shape (compile + execute, two subprocess calls); migrating it would have forced breaking its two-stage error reporting.

`mcp/tests/__init__.py` and `mcp/tests/test_network_recon_wrapper_format.py` were added — `mcp/tests/` didn't exist before this PR. Nine unit tests exercise the helper directly against synthetic `CompletedProcess` objects:
- success-with-content returns stdout
- success-with-empty-stdout returns no_match_msg
- failure surfaces `[ERROR] ... returncode=N` with stderr context
- failure with no stderr still surfaces returncode
- stderr_filter is applied to the kept-lines set
- stderr_filter trims noise from the error envelope
- ANSI codes are stripped from both stdout and stderr
- default filter keeps non-empty lines
- stderr trim cap is 2000 chars in the error path

### Testing

Both static and dynamic. The 9 unit tests for the helper pass inside the kali-sandbox container (which has the `fastmcp` dependency required to import the module). Static review of the migrated wrappers confirms each one preserves its original informational fallback string and stderr-filter rule, so legitimately-no-match scans continue to return the same operator-facing message they did before.

Runtime testing with a deliberately-failing httpx invocation against a real target was impractical because (a) the recon-orchestrator container bakes the MCP server source at build time rather than bind-mounting it (the same image-bake constraint that applies to the agent container in earlier fixes), and (b) reproducing the bug end-to-end requires a fireteam wave with an LLM-driven httpx invocation, which is hands-on operator workflow rather than a scripted reproduction. The unit-test-based verification covers the structural contract directly: any wrapper using the helper now distinguishes failure from no-match by construction.

### Risk

Low. The helper is additive (~50 lines) and the wrapper migrations are mechanical refactors that preserve the existing stderr-filter rules. The only externally-observable behavior change is that failures now produce a distinct `[ERROR] ... returncode=N` string instead of the historical `[INFO] No <thing> found` — which is the entire point of the fix. The LLM's prompts mention no specific format for these tool outputs; the new error envelope is more informative than the old conflated string.

Watch-out for reviewers:
- **`execute_hydra` exit-code semantics.** Hydra typically exits 0 on a normal run (regardless of whether credentials were found) and non-zero on argument errors, unsupported services, or panics. The current change treats any non-zero exit as failure; if hydra ever exits non-zero on a successful credential find (it shouldn't, but worth a one-time sanity check during PR review), this PR would mis-classify that as failure. The mitigation: when output is non-empty, the change wraps rather than discards it, so the credential dump remains visible.
- **`execute_arjun`'s inline implementation.** The returncode-aware error path was open-coded rather than refactored into the helper, because arjun's post-processing (`-oJ` file read) is fundamentally interleaved with the success path. The error-path string format matches the helper exactly. If a reviewer prefers, this could be refactored further by hoisting the post-processing into a callback; left as inline for now to keep the diff smaller and preserve the existing JSON-injection logic verbatim.
- **`kali_shell`'s no-match message.** Kept as `"[INFO] Command completed with no output"` for backward compat — some operators run `kali_shell "true"` knowing it produces nothing, and would be surprised by a behavior change there. The returncode check still distinguishes the silent-failure case via the new `[ERROR]` envelope, so existing usage continues to work and new failures surface explicitly.

No webapp / API / schema changes. Server-only Python in the MCP layer.

---