### PR TITLE
chore(agent): refuse startup if uvicorn workers > 1 (in-process registry)

### DIFF
--- a/agentic/Dockerfile
+++ b/agentic/Dockerfile
@@ -167,5 +167,9 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:8080/health || exit 1
 
-# Run the API server
+# Run the API server. Single-worker by design: the fireteam confirmation
+# registry uses an in-process dict (orchestrator_helpers/
+# fireteam_confirmation_registry.py). The startup guard in api.py refuses
+# to start if WORKERS / UVICORN_WORKERS / WEB_CONCURRENCY / GUNICORN_WORKERS
+# is > 1. To scale horizontally, first move the registry to a shared store.
 CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/agentic/api.py
+++ b/agentic/api.py
@@ -30,6 +30,7 @@ from pydantic import BaseModel
 from logging_config import setup_logging
 from orchestrator import AgentOrchestrator
 from orchestrator_helpers import normalize_content
+from startup_guard import check_single_worker
 from utils import get_session_count
 from websocket_api import WebSocketManager, websocket_endpoint, MessageType
 import workspace_fs
@@ -52,6 +53,12 @@ async def lifespan(app: FastAPI):
     Initializes the orchestrator and WebSocket manager on startup and cleans up on shutdown.
     """
     global orchestrator, ws_manager
+
+    # Refuse to start under multi-worker uvicorn/gunicorn. The fireteam
+    # confirmation registry uses an in-process dict; multiple workers would
+    # silently break confirmation routing. See startup_guard for the env
+    # vars consulted and the documented remediation paths.
+    check_single_worker()
 
     # Agent container runs as root; bind-mounted /workspace files would
     # otherwise end up root:root on the host (UID 1000), breaking the

--- a/agentic/orchestrator_helpers/fireteam_confirmation_registry.py
+++ b/agentic/orchestrator_helpers/fireteam_confirmation_registry.py
@@ -13,6 +13,13 @@ This registry is process-local (no cross-process sharing) and is cleared on
 member resume or wave cancellation. Not durable across backend restarts; if
 the backend dies mid-await, the whole wave is cancelled and the member is
 marked ``cancelled`` by normal fireteam cancellation semantics.
+
+The single-process invariant is enforced at startup by
+``agentic/startup_guard.py:check_single_worker()`` (called from
+``api.py``'s FastAPI lifespan). With multiple workers, registrations in
+worker A would be invisible to worker B and confirmations would silently
+hang. To scale horizontally, replace ``_PENDING`` with a shared backing
+store (Redis pub/sub, Postgres LISTEN/NOTIFY, etc.) and remove the guard.
 """
 
 import asyncio

--- a/agentic/startup_guard.py
+++ b/agentic/startup_guard.py
@@ -1,0 +1,66 @@
+"""Startup-time invariants for the agent process.
+
+The agent's fireteam confirmation registry
+(``orchestrator_helpers/fireteam_confirmation_registry.py``) tracks pending
+operator-approval state in a module-level Python dict — process-local, with
+no shared backing store. That design is correct for a single-process
+deployment (asyncio cooperative scheduling makes dict ops between awaits
+atomic) but silently breaks under multiple workers: registrations in worker
+A are invisible to worker B, confirmations route to a worker that has no
+pending entry, and members hang on ``entry.event.wait()`` until cancelled.
+
+``check_single_worker()`` refuses to start the process if any well-known
+worker-count env var indicates more than one worker. The alternative
+remediation (move the registry to a shared backing store like Redis or
+Postgres LISTEN/NOTIFY) is out of scope for this guard.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+# Env vars that operators commonly use to declare worker counts. Covers
+# uvicorn-explicit (UVICORN_WORKERS), gunicorn convention (WEB_CONCURRENCY),
+# gunicorn-explicit (GUNICORN_WORKERS), and a generic project convention
+# (WORKERS).
+_WORKER_ENV_VARS: tuple[str, ...] = (
+    "WORKERS",
+    "UVICORN_WORKERS",
+    "WEB_CONCURRENCY",
+    "GUNICORN_WORKERS",
+)
+
+
+def check_single_worker() -> None:
+    """Raise RuntimeError if any worker-count env var declares more than one
+    worker. Call from the FastAPI lifespan before any orchestrator init.
+
+    Malformed env values (non-integer) are tolerated as "unset" so a typo
+    doesn't induce a denial-of-startup.
+
+    Known limitation: a bare ``uvicorn --workers N`` CLI invocation that
+    doesn't also set one of the env vars is not detected. Operators changing
+    the deployment to multi-worker should set ``WORKERS=N`` to declare
+    intent; this guard then fires.
+    """
+    for var in _WORKER_ENV_VARS:
+        raw = os.environ.get(var)
+        if raw is None:
+            continue
+        try:
+            workers = int(raw)
+        except (ValueError, TypeError):
+            continue
+        if workers > 1:
+            msg = (
+                f"FATAL: agent registry is in-process; refusing to start with "
+                f"{var}={workers}. Either set {var}=1, or replace the in-process "
+                f"registry at orchestrator_helpers/fireteam_confirmation_registry.py "
+                f"with a shared backing store (Redis, Postgres LISTEN/NOTIFY, etc.)."
+            )
+            logger.critical(msg)
+            raise RuntimeError(msg)

--- a/agentic/tests/test_startup_guard.py
+++ b/agentic/tests/test_startup_guard.py
@@ -1,0 +1,88 @@
+"""Tests for the agent startup guard.
+
+Pins the contract: agent refuses to start if any worker-count env var
+declares more than one worker, because the fireteam confirmation registry
+is in-process and silently breaks under multi-worker deployments.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+_agentic_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _agentic_dir)
+
+from startup_guard import check_single_worker, _WORKER_ENV_VARS  # noqa: E402
+
+
+class StartupGuardTests(unittest.TestCase):
+
+    def _clear_worker_env(self):
+        """Return a dict that overrides all worker env vars to None (unset)."""
+        return {var: "" for var in _WORKER_ENV_VARS}
+
+    def test_no_env_vars_set_does_not_raise(self):
+        # Clear by setting to empty string; os.environ.get returns "" which is
+        # not None, so we also have to delete. Use a clean dict via clear=True.
+        with patch.dict(os.environ, {}, clear=True):
+            check_single_worker()  # should not raise
+
+    def test_workers_eq_1_does_not_raise(self):
+        with patch.dict(os.environ, {"WORKERS": "1"}, clear=True):
+            check_single_worker()
+
+    def test_workers_eq_4_raises_runtime_error(self):
+        with patch.dict(os.environ, {"WORKERS": "4"}, clear=True):
+            with self.assertRaises(RuntimeError) as cm:
+                check_single_worker()
+            msg = str(cm.exception)
+            self.assertIn("FATAL", msg)
+            self.assertIn("refusing to start", msg)
+            self.assertIn("WORKERS=4", msg)
+            self.assertIn("fireteam_confirmation_registry", msg)
+
+    def test_each_worker_env_var_triggers_guard(self):
+        """All four documented env var names should trip the guard."""
+        for var in _WORKER_ENV_VARS:
+            with self.subTest(var=var):
+                with patch.dict(os.environ, {var: "2"}, clear=True):
+                    with self.assertRaises(RuntimeError) as cm:
+                        check_single_worker()
+                    self.assertIn(f"{var}=2", str(cm.exception))
+
+    def test_malformed_env_value_is_tolerated(self):
+        """A typo like WORKERS=foo should NOT crash startup — treat as unset."""
+        with patch.dict(os.environ, {"WORKERS": "not-a-number"}, clear=True):
+            check_single_worker()  # should not raise
+
+    def test_workers_eq_0_does_not_raise(self):
+        """Edge case: 0 workers is nonsensical but not "more than one"."""
+        with patch.dict(os.environ, {"WORKERS": "0"}, clear=True):
+            check_single_worker()
+
+    def test_workers_eq_minus_1_does_not_raise(self):
+        """Negative values shouldn't trigger the >1 check (they're invalid in
+        a different way, not our problem to surface)."""
+        with patch.dict(os.environ, {"WORKERS": "-1"}, clear=True):
+            check_single_worker()
+
+    def test_first_offending_var_is_named_in_error(self):
+        """When multiple offending vars are set, the error names the one
+        that tripped the guard (deterministic by iteration order)."""
+        with patch.dict(
+            os.environ,
+            {"UVICORN_WORKERS": "2", "WEB_CONCURRENCY": "3"},
+            clear=True,
+        ):
+            with self.assertRaises(RuntimeError) as cm:
+                check_single_worker()
+            # WORKERS is checked first, then UVICORN_WORKERS, then
+            # WEB_CONCURRENCY — so UVICORN_WORKERS wins here.
+            self.assertIn("UVICORN_WORKERS=2", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

The fireteam confirmation registry uses a module-level Python dict to track pending operator-approval state. That design is correct for a single-process deployment but silently breaks under multiple uvicorn/gunicorn workers — registrations in worker A would be invisible to worker B, and member confirmations would hang. This PR adds a startup-time guard that refuses to start the agent if any standard worker-count env var declares more than one worker.

### Problem

`agentic/orchestrator_helpers/fireteam_confirmation_registry.py:35` declares `_PENDING: dict = {}` — a module-level Python dict, process-local with no shared backing store. The module docstring at lines 12-13 explicitly notes "process-local (no cross-process sharing)." Callers in `agentic/websocket_api.py`, `agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py`, and `agentic/orchestrator_helpers/nodes/fireteam_deploy_node.py` all read and write this dict directly.

`agentic/Dockerfile:171` runs `uvicorn api:app --host 0.0.0.0 --port 8080` with no `--workers` flag, so the default (1 worker) is used. Nothing in the code, compose files, or scripts enforces this. A future operator editing the compose `command:` to `uvicorn api:app --workers 4`, or switching to gunicorn with a non-1 worker count, would silently break confirmation routing. Concretely: half of operator decisions would land in a worker that has no `_PENDING` entry → the websocket handler logs a `RESOLVE for UNKNOWN key` warning → the member that registered the wait stays blocked on `entry.event.wait()` until the wave-timeout cancels it 30+ minutes later.

### Fix

Five files modified.

**`agentic/startup_guard.py`** (new) — exposes one function, `check_single_worker()`, which inspects four well-known worker-count env vars and raises `RuntimeError` if any indicates more than one worker. The env vars checked are `WORKERS`, `UVICORN_WORKERS`, `WEB_CONCURRENCY` (gunicorn convention), and `GUNICORN_WORKERS`. Malformed values (non-integer) are treated as unset so a typo doesn't induce a denial-of-startup. Logs `critical` before raising so the failure shows on all reasonable log handlers (project's console floor is INFO).

**`agentic/api.py`** — added `from startup_guard import check_single_worker` and calls `check_single_worker()` as the first statement inside the FastAPI `lifespan` context manager, before any logging or orchestrator init. A `RuntimeError` here causes uvicorn's startup to fail loudly with the documented message in the traceback.

**`agentic/Dockerfile`** — added a four-line comment above the `CMD ["uvicorn", "api:app", ...]` line documenting the single-worker invariant, naming the env vars the startup guard consults, and pointing at the registry's location so a future maintainer scaling horizontally has a documented remediation path (move the registry to a shared store, then remove the guard).

**`agentic/orchestrator_helpers/fireteam_confirmation_registry.py`** — extended the module docstring with a paragraph describing the startup-time enforcement, so a reader of the registry sees the contract being enforced elsewhere.

**`agentic/tests/test_startup_guard.py`** (new) — eight tests pinning the guard's behaviour:

- no env vars set → does not raise.
- `WORKERS=1` → does not raise.
- `WORKERS=4` → raises `RuntimeError` with the documented message including the var name and value.
- each of the four documented env vars triggers the guard when set > 1.
- malformed env value (`WORKERS=not-a-number`) → does not raise (graceful).
- `WORKERS=0` and `WORKERS=-1` → do not raise (edge cases, not > 1).
- when multiple offending vars are set simultaneously, the error names the first one in iteration order.

### Testing

Static only — the prompt explicitly notes runtime testing is impractical because reproducing the failure end-to-end requires deploying the agent with `--workers 4`, observing the lifespan failure, and rolling back, which the project's test environment doesn't provide scaffolding for.

What was verified:

1. Module parse for all 4 modified `.py` files passed.
2. The 8 unit tests for `check_single_worker()` pass inside the agent container, exercising the entire guard contract through the `os.environ` boundary.
3. `docker compose restart agent` was run after the change; the agent starts cleanly (with no worker env vars set) and the `/health` endpoint returns 200.

The CLI-flag detection case — `uvicorn --workers 4` invoked without also setting an env var — is NOT covered by this guard. An operator who does that bypasses the check. Mitigation: the Dockerfile comment, the registry docstring, and the startup-guard module docstring all document the env-var convention, so an operator changing the CMD has multiple places to discover the expected path.

### Risk

Very low. The change is purely additive — a new module and a one-line call in the existing lifespan. The guard's default behaviour (no env vars set, or `WORKERS=1`) is a no-op. The only failure mode this introduces is "guard fires when an operator intends multi-worker", which is exactly the documented contract enforcement: the agent refuses to start with a clear message naming the env var, the value, and the registry-file path that drives the constraint.

Watch-out for reviewers:
- **CLI-flag bypass.** As noted above, `uvicorn --workers N` without an env var doesn't trip the guard. The follow-up if the project ever wants to plug this is to inspect `sys.argv` or use a uvicorn-internal hook; both are more invasive than env-var inspection and the prompt explicitly framed env-var enforcement as the intended scope.
- **`logger.critical` before raise.** Two surfaces of the same error: a CRITICAL log line and the RuntimeError traceback uvicorn prints. Operators get both; PR reviewers should confirm both surfaces are wanted.
- **Malformed env tolerated.** `WORKERS=` (empty) or `WORKERS=foo` is treated as unset rather than crashing. If a maintainer wants stricter parsing (typos should be loud), it's a one-line change to also raise on parse failure.

Backward-compatible. No schema, API, message-shape, or behaviour changes for deployments that don't set any worker env var.

---