### PR TITLE
refactor(fireteam): remove unreachable dedup in _snapshot_parent_trace

### DIFF
--- a/agentic/orchestrator_helpers/nodes/fireteam_deploy_node.py
+++ b/agentic/orchestrator_helpers/nodes/fireteam_deploy_node.py
@@ -78,25 +78,6 @@ def _validate_mutex_groups(plan_members: list) -> Optional[str]:
     return None
 
 
-def _snapshot_parent_trace(parent_state: AgentState) -> list[dict]:
-    """Capture the parent's execution_trace plus any `_completed_step` not
-    yet merged in. Defensive against the iteration-edge case where think_node
-    decides deploy_fireteam in the same call that finalizes the prior tool's
-    output: depending on langgraph's update merge order, the freshly-analyzed
-    step may live in `_completed_step` while the trace itself still reflects
-    the pre-iteration state."""
-    trace = list(parent_state.get("execution_trace") or [])
-    completed = parent_state.get("_completed_step")
-    if completed:
-        completed_id = completed.get("step_id")
-        already_in_trace = any(
-            (s or {}).get("step_id") == completed_id for s in trace
-        ) if completed_id else False
-        if not already_in_trace:
-            trace = trace + [completed]
-    return trace
-
-
 def _build_member_state(
     parent_state: AgentState,
     spec: dict,
@@ -130,7 +111,7 @@ def _build_member_state(
         len(((parent_state.get("_current_fireteam_plan") or {}).get("members") or [])) - 1,
     )
     logger.info(
-        "[%s] member=%s SNAPSHOT parent counts: findings=%d failures=%d decisions=%d trace=%d target_keys=%d peers=%d _completed_step=%s",
+        "[%s] member=%s SNAPSHOT parent counts: findings=%d failures=%d decisions=%d trace=%d target_keys=%d peers=%d",
         parent_state.get("session_id", "?"),
         member_id,
         len(parent_state.get("chain_findings_memory") or []),
@@ -139,7 +120,6 @@ def _build_member_state(
         len(parent_state.get("execution_trace") or []),
         len(parent_state.get("target_info") or {}),
         _peer_count,
-        bool(parent_state.get("_completed_step")),
     )
 
     base: dict = {
@@ -174,18 +154,10 @@ def _build_member_state(
         # attribution), failed attempts, decisions, and recent tool outputs
         # instead of a 200-char-per-step trace that omits the artifacts they
         # need (captured JWTs, cleared endpoints, registered users, etc.).
-        #
-        # Edge case: when the parent decides to deploy_fireteam in the same
-        # think_node iteration that processes the prior tool's output, the
-        # latest step may live in `_completed_step` while `execution_trace`
-        # still reflects the pre-iteration state (depending on how langgraph
-        # serialized the updates between nodes). Belt-and-suspenders: merge
-        # `_completed_step` into the snapshot if it's not already in the
-        # trace. Dedup by step_id.
         "_parent_chain_findings": list(parent_state.get("chain_findings_memory") or []),
         "_parent_chain_failures": list(parent_state.get("chain_failures_memory") or []),
         "_parent_chain_decisions": list(parent_state.get("chain_decisions_memory") or []),
-        "_parent_execution_trace": _snapshot_parent_trace(parent_state),
+        "_parent_execution_trace": list(parent_state.get("execution_trace") or []),
 
         # Sibling member specs for this wave (everyone in the plan except this
         # member). Rendered into the system prompt as an "out of scope" block


### PR DESCRIPTION
### Summary

`_snapshot_parent_trace` in the fireteam deploy node hedged against a LangGraph "trace lags behind `_completed_step`" race that can't actually fire — every code path that writes the parent's `_completed_step` writes the matching `execution_trace` append in the same return-dict, and LangGraph applies node returns atomically. The helper's dedup branch is unreachable; its accompanying comment spreads FUD about LangGraph merge semantics that the code doesn't support. This PR removes the helper, inlines the single call site, and drops the diagnostic SNAPSHOT log column that was paired with the dead code.

### Problem

`agentic/orchestrator_helpers/nodes/fireteam_deploy_node.py` (lines 81-97 before this PR) defined:

```python
def _snapshot_parent_trace(parent_state: AgentState) -> list[dict]:
    """Capture the parent's execution_trace plus any `_completed_step` not
    yet merged in. Defensive against the iteration-edge case where think_node
    decides deploy_fireteam in the same call that finalizes the prior tool's
    output: depending on langgraph's update merge order, the freshly-analyzed
    step may live in `_completed_step` while the trace itself still reflects
    the pre-iteration state."""
    trace = list(parent_state.get("execution_trace") or [])
    completed = parent_state.get("_completed_step")
    if completed:
        completed_id = completed.get("step_id")
        already_in_trace = any(
            (s or {}).get("step_id") == completed_id for s in trace
        ) if completed_id else False
        if not already_in_trace:
            trace = trace + [completed]
    return trace
```

Auditing every parent-state write site for `_completed_step`:

- `agentic/orchestrator_helpers/nodes/think_node.py:836-839` (analysis path):
  ```python
  execution_trace = state.get("execution_trace", []) + [pending_step]
  updates["execution_trace"] = execution_trace
  updates["target_info"] = merged_target.model_dump()
  updates["_completed_step"] = pending_step
  ```
- `agentic/orchestrator_helpers/nodes/think_node.py:848-850` (fallback path): same pattern — appends to trace AND sets `_completed_step` in one update.
- All other parent-state references (`orchestrator.py:1381,1456,1581`, `think_node.py:618`, `tool_confirmation_nodes.py:59`) are RESETS to `None`.

`execution_trace` in `agentic/state.py:663` is a plain `List[dict]` with no reducer annotation, so a node return REPLACES the field wholesale. The hypothetical "trace reflects pre-iteration state while `_completed_step` is current" race requires `execution_trace` to be omitted from the update while `_completed_step` is included — that combination does not occur anywhere. The dedup branch (`if not already_in_trace: trace = trace + [completed]`) is unreachable through any current code path.

A paired diagnostic log line at line 132-143 (before this PR) printed `_completed_step=%s` alongside the SNAPSHOT counters specifically to detect this race. The introducing commit (`61ea3b6`, 2026-05-05) shipped the helper and the logger together; the logger's presence is itself a tell that the author wasn't sure the race fires.

### Fix

`agentic/orchestrator_helpers/nodes/fireteam_deploy_node.py`:

1. Deleted the `_snapshot_parent_trace` function (17 lines including docstring).
2. Replaced its single call site in `_build_member_state` with the inline equivalent: `"_parent_execution_trace": list(parent_state.get("execution_trace") or [])`.
3. Removed the corresponding "Edge case" comment block (7 lines) that explained the now-removed dedup using the same misleading LangGraph-merge-order claim. The remaining comment above the field still documents what `_parent_execution_trace` is for (rendered into the member's system prompt via `format_chain_context`) without referencing the phantom race.
4. Dropped the `_completed_step=%s` column from the SNAPSHOT diagnostic log line, plus its corresponding `bool(parent_state.get("_completed_step"))` argument. The other SNAPSHOT columns (findings / failures / decisions / trace / target_keys / peers) stay — they're still useful for detecting other state-plumbing issues.

Net diff: -28 lines.

### Testing

Static only — the prompt explicitly noted runtime testing is impractical because reproducing the (non-)race would require constructing a parent state with `_completed_step` populated and `execution_trace` not yet updated, which the analysis above shows can't happen through any current code path.

What was verified:

1. Module-parse for the modified file passed.
2. All 10 neighboring fireteam-regression tests pass after the change (`WaveTimeoutDbPersistRegression`, `WaveTimeoutPreservesPartialStateRegression`, `WaveTimeoutWebsocketEmitRegression`, `FindingConversionPerItemExceptionRegression`, `WaveClockExcludesConfirmationWaitRegression`).
3. Confirmed via `grep` that `_snapshot_parent_trace` and `_completed_step` no longer appear in `fireteam_deploy_node.py`. No other callers existed (verified before the change).
4. Agent container restarted cleanly with the updated source.

The two existing tests that reference `_parent_execution_trace` (`tests/test_soft_allowlist.py:84` and `tests/test_peer_task_scope.py:87`) construct it directly as an empty list and never exercised the removed dedup branch, so they continue to pass without modification.

### Risk

Very low. The change removes unreachable code; the wrapper's only non-trivial branch was the `if not already_in_trace: trace = trace + [completed]` path, which has been confirmed unreachable through current code paths. Replacing the helper call with the inline `list(...)` copy produces identical results in every reachable state.

Watch-out for reviewers:

- **If a future code path ever writes `_completed_step` without the matching `execution_trace` append, this PR makes that bug visible at the member level (member sees stale parent trace) rather than papering over it.** That's arguably an improvement — surface a real ordering bug instead of hiding it — but worth flagging if the maintainer wants the belt-and-suspenders kept "just in case." The prompt offered Option B (keep the helper but rewrite the misleading comment) as an alternative; I went with Option A (remove) since the prompt recommended it and the verdict's "the current state is the worst of both" framing argues against the half-measure.
- **Log column drop.** The SNAPSHOT log loses one column; downstream log parsers grep-matching on `_completed_step=` would need to be updated.

No schema, API, or behaviour changes. Server-only Python.

---