### PR TITLE
fix(fireteam): enforce member iter budget after final analysis pass

### DIFF
--- a/agentic/orchestrator_helpers/fireteam_member_graph.py
+++ b/agentic/orchestrator_helpers/fireteam_member_graph.py
@@ -30,6 +30,20 @@ def _route_after_member_think(state: FireteamMemberState) -> str:
     decision = state.get("_decision") or {}
     action = decision.get("action")
 
+    # Iteration budget cap (post-think). Strict-greater so the LLM gets one
+    # extra call to analyze the last dispatched wave: with max_iterations=N,
+    # the Nth think call plans wave N, execute_plan runs wave N, and the
+    # (N+1)th think call analyzes wave N's output. After that call,
+    # current_iteration=N+1 > N and we route to completion. The strict-greater
+    # accounts for the member's wave-then-analyze cadence: the root agent
+    # fuses analysis+planning in one LLM call and uses >= at
+    # orchestrator.py:_route_after_think, while the member's analysis happens
+    # in the LLM call AFTER the wave executes.
+    current_iter = state.get("current_iteration", 0)
+    max_iter = state.get("max_iterations", 15)
+    if current_iter > max_iter:
+        return "fireteam_complete"
+
     if state.get("_pending_confirmation"):
         return "fireteam_await_confirmation"
 

--- a/agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py
+++ b/agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py
@@ -900,18 +900,12 @@ async def fireteam_member_think_node(
     if graph_view_cyphers:
         set_graph_view_context(graph_view_cyphers.get(session_id))
 
-    # ---- Budget enforcement (before any LLM call) ----
+    # Iteration budget is enforced by _route_after_member_think (strict-greater
+    # so the LLM gets one analysis pass after the cap is hit, persisting the
+    # final wave's chain_findings). tokens_used is accumulated below for
+    # passive observability only (metrics, report, UI).
     current_iter = state.get("current_iteration", 0)
     max_iter = state.get("max_iterations", 15)
-    if current_iter >= max_iter:
-        logger.info("[%s] member %s iteration budget exhausted (%d/%d)", session_id, member_id, current_iter, max_iter)
-        return {
-            "task_complete": True,
-            "completion_reason": "iteration_budget_exceeded",
-        }
-
-    # Iteration budget is the sole runtime cap; tokens_used is accumulated
-    # below for passive observability only (metrics, report, UI).
     tokens_used = state.get("tokens_used", 0)
 
     # ---- LLM call with parse-retry loop (mirrors root think_node) ----
@@ -1589,12 +1583,30 @@ async def fireteam_member_think_node(
         else:
             update["_current_plan"] = None
 
+    # Iteration budget signal: if we entered this call with current_iter
+    # already at max, the LLM has just run the post-budget analysis pass on
+    # the last wave's output. Set task_complete + completion_reason so the
+    # streaming layer and FireteamMemberResult see the right terminate reason.
+    # The router-side cap in _route_after_member_think (strict-greater) is
+    # the actual routing signal; this is for observability and to suppress
+    # the dangerous-tool escalation below (no point pausing for operator
+    # approval when the member is about to exit).
+    if current_iter >= max_iter:
+        update["task_complete"] = True
+        update["completion_reason"] = "iteration_budget_exceeded"
+        logger.info(
+            "[%s] member %s analysis pass after budget exhaustion (%d/%d) — terminating",
+            session_id, member_id, current_iter, max_iter,
+        )
+
     # Dangerous-tool escalation runs AFTER analysis-write so the prior wave's
     # chain_findings, target_info merge, and Neo4j writes commit before we
     # pause for operator approval. `_pending_confirmation` is the router's
     # signal to fireteam_await_confirmation — its placement in this function
     # does not affect routing, only whether analysis-write fires first.
-    if is_dangerous:
+    # Skipped when budget is exhausted (above): the member is terminating,
+    # so a new dangerous wave should not be queued for operator approval.
+    if is_dangerous and not update.get("task_complete"):
         pending = _build_pending_confirmation(decision, state)
         update["_pending_confirmation"] = pending
         # Populate _current_plan / _current_step so they survive the await


### PR DESCRIPTION
> **Depends on #117.** Please review and merge #117 first; once that merges, this PR's diff will auto-reduce to contain only the iter-budget changes (the second of two commits on this branch).


### Summary

Fireteam members were terminating one think call too early, dropping the final wave's analysis on the floor. The pre-LLM iteration-budget gate inside the member's think node returned before the LLM could analyze the last-dispatched wave's tool output, so `chain_findings`, target-info merge, and Neo4j writes for that wave were never produced. The fix removes the pre-LLM gate and replaces it with a router-side cap, mirroring the pattern the root agent already uses — with a small adjustment for the member's wave-then-analyze cadence.

### Problem

`agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py:841-849` enforced the member's iteration budget BEFORE the LLM call: when entering the think node with `current_iteration >= max_iterations`, the node returned `{"task_complete": True, "completion_reason": "iteration_budget_exceeded"}` immediately, with no LLM round-trip. This is asymmetric to the root agent, which has no internal budget gate; the root enforces the cap router-side at `agentic/orchestrator.py:954-958`, AFTER `think_node` has run and produced its analysis output.

The asymmetry produced a real data-loss path. With `max_iterations=N`, the Nth think call planned wave N and `execute_plan` dispatched it. The wave's tool outputs landed in `_current_plan.steps[*].tool_output`. The next think call (the (N+1)th) would have analyzed those outputs and emitted `chain_findings` — but the pre-LLM gate fired first, dropping the wave. Empirically, this caused recon-only fireteam members to finish with `findings=0` despite running successful tool waves that produced thousands of bytes of structured output.

### Fix

Two coordinated changes:

1. `agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py` — removed the pre-LLM budget gate (formerly lines 841-849). The `current_iter` / `max_iter` reads are kept (they're used downstream and by the new budget signal). Added a post-LLM budget signal block immediately before the dangerous-tool escalation: when entering with `current_iter >= max_iter`, the LLM has just run its post-budget analysis pass, so `update["task_complete"] = True` and `update["completion_reason"] = "iteration_budget_exceeded"` are set for the streaming layer and `FireteamMemberResult`. The dangerous-tool escalation block is now gated on `not update.get("task_complete")` so a terminating member doesn't queue a new dangerous wave for operator approval.

2. `agentic/orchestrator_helpers/fireteam_member_graph.py` — added a router-side iteration cap at the top of `_route_after_member_think`: when `state.get("current_iteration") > state.get("max_iterations")`, route directly to `fireteam_complete`. Mirrors `orchestrator.py:_route_after_think` in shape and placement.

The router check uses **strict-greater** (`>`) rather than the root's `>=`. Member's wave-then-analyze cadence requires one more LLM call than root's fuse-in-one-call pattern; strict-greater is the minimal adjustment that delivers this without redefining `max_iterations` semantics. Specifically: the root agent fuses analysis-of-pending-output with planning-of-next-action in a single LLM call, so the same call that bumps `current_iteration` to `max` is also the last analysis pass, and `>=` is sufficient. The member's analysis happens in the LLM call AFTER the wave executes, so when `current_iteration` reaches `max` the wave-N output has just been dispatched and the wave-N analysis needs one more think call. After that call, `current_iteration = max + 1`, the strict-greater check fires, and the member terminates with the wave-N findings already persisted.

### Testing

Static verification only. Runtime testing was impractical because triggering the cap requires creating a project, launching a fireteam wave with at least one recon-only specialist, approving operator-confirmation popups across multiple iterations, and querying Postgres / Neo4j to verify `chain_findings_memory` for the final wave — a hands-on workflow rather than a scripted reproduction. The agent container also bakes source via `agentic/Dockerfile` COPY (no bind-mount on `agentic/`), so a `docker compose build agent` would be needed before any runtime test could exercise the change.

Static verification traced `max_iterations=3` end-to-end:

| Think call | State in | Analysis-write | Budget signal | Router decision |
|---|---|---|---|---|
| 1 | iter=0 | (no pending) | 0≥3 → no | 1>3 NO → execute |
| 2 | iter=1 | wave-1 findings | 1≥3 → no | 2>3 NO → execute |
| 3 | iter=2 | wave-2 findings | 2≥3 → no | 3>3 NO → execute |
| 4 | iter=3 | **wave-3 findings** | **3≥3 → task_complete, completion_reason** | **4>3 YES → fireteam_complete** |

Result: all three waves analyzed (the JIRA test criterion). No phantom `_pending_confirmation` on the terminating call (because the is_dangerous block is gated on `not task_complete`). `completion_reason` set to `"iteration_budget_exceeded"` on the terminating call's update dict.

Edge cases checked statically:
- `max_iter=0`: 1 analysis-only LLM call, then terminate. No waves dispatched.
- `max_iter=1`: 2 LLM calls, 1 wave dispatched, wave-1 analyzed before terminate.
- `action="complete"` emitted before budget: completion_reason preserves the LLM's reason (the budget signal only fires when `current_iter >= max_iter`, so it doesn't overwrite at lower iterations).
- Simultaneous `action="complete"` + budget hit: budget signal overrides `completion_reason` to `"iteration_budget_exceeded"`. Acceptable — budget is the actual hard cap.

Module-parse check (`python -c "import ast; ast.parse(...)"`) passed for both modified files.

### Risk

Adds one LLM call per member compared to the buggy behavior. With Opus pricing the marginal cost is small relative to the typical wave cost. If maintainer prefers Option A semantics (strict mirror of root, accepting that one wave is sacrificed for cost), that's a one-line change — happy to follow up.

Other risk areas reviewers should pay attention to:
- The router cap check sits BEFORE the `_pending_confirmation` check. This is intentional: if the LLM at the (N+1)th call plans a dangerous tool, we suppress the escalation (the is_dangerous block is gated on `not task_complete`). Reviewers should confirm this is the desired behavior — alternative would be to keep the escalation and let the operator decide if the member should continue past budget.
- The strict-greater (`>`) check differs from `orchestrator.py:_route_after_think`'s `>=`. This is documented inline at `_route_after_member_think` and in the Fix section above; the asymmetry is structural (analysis fusion vs. separation), not a copy-paste error.

No schema, API, or message-shape changes. Server-only Python.

---

