### PR TITLE
fix(fireteam): exclude operator confirmation wait from wave wall-clock budget

### DIFF
--- a/agentic/orchestrator_helpers/fireteam_confirmation_registry.py
+++ b/agentic/orchestrator_helpers/fireteam_confirmation_registry.py
@@ -17,6 +17,7 @@ marked ``cancelled`` by normal fireteam cancellation semantics.
 
 import asyncio
 import logging
+import time
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -33,6 +34,70 @@ class PendingMemberConfirmation:
 
 
 _PENDING: dict[tuple[str, str, str], PendingMemberConfirmation] = {}
+
+
+# Wave-clock credit accounting (FAPP-46). Tracks wall-clock time spent waiting
+# on operator confirmation, per wave, using interval-union semantics: when N
+# members wait in parallel for 60s, the wave's effective deadline is extended
+# by 60s (not 60s * N). The deploy node's deadline loop reads get_credit_s and
+# adjusts its wave-timeout deadline accordingly so operator delay does not
+# consume the wave wall-clock budget.
+_WAVE_ACTIVE_WAITS: dict[tuple[str, str], int] = {}     # currently-waiting member count
+_WAVE_PAUSE_START: dict[tuple[str, str], float] = {}    # monotonic when count went 0→1
+_WAVE_CREDIT_S:    dict[tuple[str, str], float] = {}    # accumulated paused time
+
+
+def _wkey(session_id: str, wave_id: str) -> tuple[str, str]:
+    return (session_id, wave_id)
+
+
+def begin_confirmation_wait(session_id: str, wave_id: str) -> None:
+    """Mark the start of one member's confirmation wait. Increments the wave's
+    in-progress count and starts the pause clock on the 0→1 transition.
+    Idempotent under nested/parallel waits within the same wave."""
+    k = _wkey(session_id, wave_id)
+    count = _WAVE_ACTIVE_WAITS.get(k, 0)
+    if count == 0:
+        _WAVE_PAUSE_START[k] = time.monotonic()
+    _WAVE_ACTIVE_WAITS[k] = count + 1
+
+
+def end_confirmation_wait(session_id: str, wave_id: str) -> None:
+    """Mark the end of one member's confirmation wait. On 1→0 transition,
+    accumulates the elapsed interval into the wave's credit total. Must be
+    called even on exception/cancellation (use try/finally at the caller) so
+    the count balances; otherwise the wave clock would be stuck-paused."""
+    k = _wkey(session_id, wave_id)
+    count = _WAVE_ACTIVE_WAITS.get(k, 0) - 1
+    if count <= 0:
+        start = _WAVE_PAUSE_START.pop(k, None)
+        if start is not None:
+            elapsed = time.monotonic() - start
+            _WAVE_CREDIT_S[k] = _WAVE_CREDIT_S.get(k, 0.0) + elapsed
+        _WAVE_ACTIVE_WAITS.pop(k, None)
+    else:
+        _WAVE_ACTIVE_WAITS[k] = count
+
+
+def get_credit_s(session_id: str, wave_id: str) -> float:
+    """Return the wave's accumulated confirmation-wait credit in seconds,
+    including any in-progress wait. Monotonically non-decreasing for a given
+    wave until drop_wave_credit clears the entry."""
+    k = _wkey(session_id, wave_id)
+    base = _WAVE_CREDIT_S.get(k, 0.0)
+    start = _WAVE_PAUSE_START.get(k)
+    if start is not None:
+        return base + (time.monotonic() - start)
+    return base
+
+
+def drop_wave_credit(session_id: str, wave_id: str) -> None:
+    """Clear all credit-tracking state for a wave. Called on wave teardown
+    alongside drop_wave."""
+    k = _wkey(session_id, wave_id)
+    _WAVE_ACTIVE_WAITS.pop(k, None)
+    _WAVE_PAUSE_START.pop(k, None)
+    _WAVE_CREDIT_S.pop(k, None)
 
 
 def _key(session_id: str, wave_id: str, member_id: str) -> tuple[str, str, str]:

--- a/agentic/orchestrator_helpers/nodes/fireteam_deploy_node.py
+++ b/agentic/orchestrator_helpers/nodes/fireteam_deploy_node.py
@@ -482,7 +482,7 @@ async def fireteam_deploy_node(
     plan_data["fireteam_id"] = fireteam_id_key
 
     max_concurrent = get_setting("FIRETEAM_MAX_CONCURRENT", 3)
-    timeout_s = get_setting("FIRETEAM_TIMEOUT_SEC", 1800)
+    timeout_s = get_setting("FIRETEAM_TIMEOUT_SEC", 7200)
     sem = asyncio.Semaphore(max_concurrent)
 
     # ---- Observability: wave deploy header ----
@@ -667,21 +667,60 @@ async def fireteam_deploy_node(
 
     wave_start = time.monotonic()
     results: list = []
+    # Wave-clock semantics: operator confirmation wait does NOT consume the
+    # wave wall-clock. Members register begin/end_confirmation_wait around
+    # their await; this loop polls get_credit_s and extends the deadline by
+    # any new credit. Without this, a slow operator drains the budget before
+    # tools run (the `await asyncio.wait_for(entry.event.wait(), ...)` in
+    # fireteam_await_confirmation_node is just a normal `await` from the
+    # event loop's perspective and accumulates against an outer timer).
+    from orchestrator_helpers.fireteam_confirmation_registry import (
+        get_credit_s as _get_credit_s,
+    )
     try:
-        raw = await asyncio.wait_for(
-            asyncio.gather(*tasks, return_exceptions=True),
-            timeout=timeout_s,
-        )
-        results = [
-            r if isinstance(r, dict) else _error_result(m, mid, r, time.monotonic() - wave_start)
-            for r, m, mid in zip(raw, members, member_ids)
-        ]
+        deadline = wave_start + timeout_s
+        last_credit = 0.0
+        pending = set(tasks)
+        while pending:
+            new_credit = _get_credit_s(session_id, fireteam_id_key) - last_credit
+            if new_credit > 0:
+                deadline += new_credit
+                last_credit += new_credit
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise asyncio.TimeoutError()
+            # Poll at 1s granularity so credit changes (operator approval
+            # mid-wait) are picked up promptly. asyncio.wait returns earlier
+            # if any task completes, so the overhead is bounded.
+            _, pending = await asyncio.wait(
+                pending,
+                timeout=min(remaining, 1.0),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        # All tasks completed before deadline. Match the previous
+        # `asyncio.gather(..., return_exceptions=True)` shape: collect each
+        # task's result, or wrap any raised exception into an _error_result.
+        results = []
+        for t, m, mid in zip(tasks, members, member_ids):
+            try:
+                r = t.result()
+            except BaseException as exc:  # task raised
+                results.append(_error_result(m, mid, exc, time.monotonic() - wave_start))
+                continue
+            if isinstance(r, dict):
+                results.append(r)
+            else:
+                results.append(_error_result(m, mid, r, time.monotonic() - wave_start))
     except asyncio.TimeoutError:
         logger.warning("[%s] fireteam %s timed out after %ds", session_id, fireteam_id_key, timeout_s)
         # Wake any members currently parked on the confirmation registry so
         # t.cancel() below doesn't race a forever-blocked asyncio.wait().
-        from orchestrator_helpers.fireteam_confirmation_registry import drop_wave as _drop_wave
+        from orchestrator_helpers.fireteam_confirmation_registry import (
+            drop_wave as _drop_wave,
+            drop_wave_credit as _drop_wave_credit,
+        )
         _drop_wave(session_id, fireteam_id_key, reason="wave_timeout")
+        _drop_wave_credit(session_id, fireteam_id_key)
         for t in tasks:
             if not t.done():
                 t.cancel()
@@ -742,8 +781,12 @@ async def fireteam_deploy_node(
                     logger.exception("timeout emit member_completed failed")
     except asyncio.CancelledError:
         logger.info("[%s] fireteam %s cancelled by operator", session_id, fireteam_id_key)
-        from orchestrator_helpers.fireteam_confirmation_registry import drop_wave as _drop_wave
+        from orchestrator_helpers.fireteam_confirmation_registry import (
+            drop_wave as _drop_wave,
+            drop_wave_credit as _drop_wave_credit,
+        )
         _drop_wave(session_id, fireteam_id_key, reason="wave_cancelled")
+        _drop_wave_credit(session_id, fireteam_id_key)
         for t in tasks:
             if not t.done():
                 t.cancel()
@@ -812,6 +855,13 @@ async def fireteam_deploy_node(
 
     wall = time.monotonic() - wave_start
     status_counts = _count_statuses(results)
+
+    # Clean up wave-clock credit tracking. The timeout / cancel branches do
+    # their own drop_wave_credit; this handles the normal-completion path.
+    from orchestrator_helpers.fireteam_confirmation_registry import (
+        drop_wave_credit as _drop_wave_credit_final,
+    )
+    _drop_wave_credit_final(session_id, fireteam_id_key)
 
     # Overall fireteam status: timeout if any timeout, else completed.
     if status_counts.get("timeout", 0) > 0:

--- a/agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py
+++ b/agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py
@@ -1100,54 +1100,6 @@ async def fireteam_member_think_node(
     # defining it here, the is_dangerous branch crashed with NameError.
     analysis = decision.output_analysis
 
-    if is_dangerous:
-        pending = _build_pending_confirmation(decision, state)
-        update["_pending_confirmation"] = pending
-        # FIX: Populate _current_plan / _current_step now so they survive
-        # the await round-trip. Without this, the await node returns to
-        # the router with these fields unset and the router falls back to
-        # fireteam_think -> infinite plan/approve loop, no tool execution.
-        if decision.action == "plan_tools" and decision.tool_plan:
-            update["_current_plan"] = decision.tool_plan.model_dump()
-        elif decision.action == "use_tool":
-            update["_current_step"] = {
-                "step_id": uuid4().hex,
-                "iteration": current_iter + 1,
-                "phase": state.get("current_phase"),
-                "tool_name": decision.tool_name,
-                "tool_args": decision.tool_args or {},
-                "thought": decision.thought,
-                "reasoning": decision.reasoning,
-            }
-        # Even though we're escalating the NEW decision, the PREVIOUS
-        # single-tool step (if any) is now completed — its output was the
-        # input to this think call. Signal it to the streaming layer so the
-        # UI flips the prior tool card from `running` to `success/error`.
-        # Without this, the frontend sees: tool_start → (never completes) →
-        # pending-approval card, and the prior tool stays stuck visually.
-        if has_pending_single_output and prev_step:
-            completed_prev = dict(prev_step)
-            if analysis is not None:
-                completed_prev["output_analysis"] = (
-                    analysis.interpretation
-                    or (prev_step.get("tool_output") or "")
-                )[:20000]
-                completed_prev["actionable_findings"] = list(analysis.actionable_findings or [])
-                completed_prev["recommended_next_steps"] = list(analysis.recommended_next_steps or [])
-            else:
-                completed_prev["output_analysis"] = (prev_step.get("tool_output") or "")[:20000]
-                completed_prev["actionable_findings"] = []
-                completed_prev["recommended_next_steps"] = []
-            update["_completed_step"] = completed_prev
-        logger.info(
-            "[%s] member %s escalating dangerous tool for parent approval: %s",
-            session_id, member_id,
-            decision.tool_name or [s.tool_name for s in (decision.tool_plan.steps if decision.tool_plan else [])],
-        )
-        # Router will send us to fireteam_await_confirmation because
-        # _pending_confirmation is set.
-        return update
-
     # If action is complete, ensure task_complete is True so the router exits.
     if decision.action == "complete":
         update["task_complete"] = True
@@ -1499,5 +1451,55 @@ async def fireteam_member_think_node(
             pass  # update["_current_plan"] already set to the new plan above
         else:
             update["_current_plan"] = None
+
+    # Dangerous-tool escalation runs AFTER analysis-write so the prior wave's
+    # chain_findings, target_info merge, and Neo4j writes commit before we
+    # pause for operator approval. `_pending_confirmation` is the router's
+    # signal to fireteam_await_confirmation — its placement in this function
+    # does not affect routing, only whether analysis-write fires first.
+    if is_dangerous:
+        pending = _build_pending_confirmation(decision, state)
+        update["_pending_confirmation"] = pending
+        # Populate _current_plan / _current_step so they survive the await
+        # round-trip. Without this, the await node returns to the router
+        # with these fields unset and the router falls back to fireteam_think
+        # -> infinite plan/approve loop, no tool execution.
+        if decision.action == "plan_tools" and decision.tool_plan:
+            update["_current_plan"] = decision.tool_plan.model_dump()
+        elif decision.action == "use_tool":
+            update["_current_step"] = {
+                "step_id": uuid4().hex,
+                "iteration": current_iter + 1,
+                "phase": state.get("current_phase"),
+                "tool_name": decision.tool_name,
+                "tool_args": decision.tool_args or {},
+                "thought": decision.thought,
+                "reasoning": decision.reasoning,
+            }
+        # Even though we're escalating the NEW decision, the PREVIOUS
+        # single-tool step (if any) is now completed — its output was the
+        # input to this think call. Signal it to the streaming layer so the
+        # UI flips the prior tool card from `running` to `success/error`.
+        # Without this, the frontend sees: tool_start → (never completes) →
+        # pending-approval card, and the prior tool stays stuck visually.
+        if has_pending_single_output and prev_step:
+            completed_prev = dict(prev_step)
+            if analysis is not None:
+                completed_prev["output_analysis"] = (
+                    analysis.interpretation
+                    or (prev_step.get("tool_output") or "")
+                )[:20000]
+                completed_prev["actionable_findings"] = list(analysis.actionable_findings or [])
+                completed_prev["recommended_next_steps"] = list(analysis.recommended_next_steps or [])
+            else:
+                completed_prev["output_analysis"] = (prev_step.get("tool_output") or "")[:20000]
+                completed_prev["actionable_findings"] = []
+                completed_prev["recommended_next_steps"] = []
+            update["_completed_step"] = completed_prev
+        logger.info(
+            "[%s] member %s escalating dangerous tool for parent approval: %s",
+            session_id, member_id,
+            decision.tool_name or [s.tool_name for s in (decision.tool_plan.steps if decision.tool_plan else [])],
+        )
 
     return update

--- a/agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py
+++ b/agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py
@@ -60,6 +60,8 @@ async def fireteam_await_confirmation_node(
     from orchestrator_helpers.fireteam_confirmation_registry import (
         register as _register,
         drop as _drop,
+        begin_confirmation_wait as _begin_wait,
+        end_confirmation_wait as _end_wait,
     )
 
     pending = state.get("_pending_confirmation") or {}
@@ -110,6 +112,12 @@ async def fireteam_await_confirmation_node(
         [t.get("tool_name") for t in (pending.get("tools") or [])],
     )
 
+    # Mark this member as in operator-wait so the deploy node's wave-clock
+    # deadline pauses (interval-union semantics: parallel waits do not
+    # double-count). The finally branch guarantees the count balances even
+    # on TimeoutError or CancelledError; otherwise the wave clock would be
+    # stuck-paused for the rest of the wave.
+    _begin_wait(session_id, wave_id)
     try:
         await asyncio.wait_for(entry.event.wait(), timeout=timeout_s)
         decision = entry.decision or "reject"
@@ -124,6 +132,7 @@ async def fireteam_await_confirmation_node(
         _drop(session_id, wave_id, member_id)
         raise
     finally:
+        _end_wait(session_id, wave_id)
         _drop(session_id, wave_id, member_id)
 
     if decision == "approve":

--- a/agentic/tests/test_fireteam_regressions.py
+++ b/agentic/tests/test_fireteam_regressions.py
@@ -605,5 +605,409 @@ class WaveTimeoutWebsocketEmitRegression(unittest.IsolatedAsyncioTestCase):
                              f"per-member emit must carry status=timeout; got {call.kwargs}")
 
 
+# =============================================================================
+# BUG: Wave-timeout reported zero counters / no findings for productive members.
+# =============================================================================
+#
+# When FIRETEAM_TIMEOUT_SEC fires while a member is mid-execution, the closure-
+# local ``final_state`` inside ``_run_one`` is GC'd at cancellation, and the
+# outer timeout handler built ``_timeout_result(spec, mid, wall_s)`` which
+# hardcoded iterations_used=0, tokens_used=0 and defaulted findings=[]. Those
+# zeros were PATCHed to Postgres and propagated to the UI.
+#
+# Fix: snapshot-by-reference. ``_run_one`` registers a reference to its
+# ``final_state`` in an outer-scope ``member_snapshots`` dict; the in-place
+# ``.update(node_update)`` mutations in the astream loop keep the reference
+# current. The timeout handler reads from that map via
+# ``_timeout_result_from_snapshot`` (which reuses ``_result_from_final_state``
+# and overrides status/completion_reason).
+
+
+def _mid_flight_graph_factory(
+    *,
+    iterations_used: int = 2,
+    input_tokens: int = 1500,
+    output_tokens: int = 300,
+    findings: list | None = None,
+    delay_s: float = 5.0,
+):
+    """Member graph that yields a productive in-flight state update once,
+    then sleeps past the wave timeout. Simulates a member that did real work
+    before being cancelled by the outer wave-timeout handler."""
+    if findings is None:
+        findings = [{
+            "finding_type": "service_identified",
+            "severity": "info",
+            "title": "nginx 1.18 banner",
+            "evidence": "Server: nginx/1.18",
+            "confidence": 100,
+            "step_iteration": 1,
+        }]
+
+    class _MidFlightGraph:
+        async def _run(self, s, config=None):
+            yield {
+                "fireteam_think": {
+                    "current_iteration": iterations_used,
+                    "tokens_used": input_tokens + output_tokens,
+                    "input_tokens_used": input_tokens,
+                    "output_tokens_used": output_tokens,
+                    "chain_findings_memory": list(findings),
+                    "execution_trace": [],
+                    "target_info": {},
+                }
+            }
+            await asyncio.sleep(delay_s)
+
+        def astream(self, s, config=None):
+            return self._run(s, config)
+    return _MidFlightGraph()
+
+
+class WaveTimeoutPreservesPartialStateRegression(unittest.IsolatedAsyncioTestCase):
+    """Locks the fix: cancelled members surface real iter/token/findings
+    counts from their in-flight final_state rather than all-zeros."""
+
+    async def test_patch_body_carries_in_flight_iterations_and_tokens(self):
+        from orchestrator_helpers.nodes.fireteam_deploy_node import fireteam_deploy_node
+
+        patch_member_mock = AsyncMock()
+        with patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node._persist_deploy",
+            new=AsyncMock(return_value="id"),
+        ), patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node._patch_member",
+            new=patch_member_mock,
+        ), patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node._patch_fireteam",
+            new=AsyncMock(),
+        ), patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node.get_setting",
+            side_effect=_settings_for_timeout_test(),
+        ):
+            await fireteam_deploy_node(
+                _parent_state(n_members=1), None,
+                member_graph=_mid_flight_graph_factory(
+                    iterations_used=2,
+                    input_tokens=1500,
+                    output_tokens=300,
+                ),
+                streaming_callbacks={},
+                neo4j_creds=None,
+            )
+
+        self.assertGreater(len(patch_member_mock.call_args_list), 0,
+                           "no _patch_member calls — DB never updated")
+        last_body = patch_member_mock.call_args_list[-1].args[3]
+        self.assertEqual(last_body["status"], "timeout")
+        self.assertEqual(last_body["completionReason"], "wave_timeout")
+        self.assertEqual(
+            last_body["iterationsUsed"], 2,
+            f"expected real iterationsUsed=2 from in-flight snapshot, "
+            f"got {last_body.get('iterationsUsed')}",
+        )
+        self.assertEqual(
+            last_body["tokensUsed"], 1800,
+            f"expected real tokensUsed=1800 (1500+300), "
+            f"got {last_body.get('tokensUsed')}",
+        )
+        self.assertEqual(
+            last_body["findingsCount"], 1,
+            f"expected findingsCount=1 from in-flight chain_findings_memory, "
+            f"got {last_body.get('findingsCount')}",
+        )
+
+    def test_timeout_result_from_snapshot_with_populated_state(self):
+        """Unit test for the helper: populated snapshot → real counts +
+        timeout labels."""
+        from orchestrator_helpers.nodes.fireteam_deploy_node import (
+            _timeout_result_from_snapshot,
+        )
+
+        snapshot = {
+            "current_iteration": 3,
+            "tokens_used": 2400,
+            "input_tokens_used": 2000,
+            "output_tokens_used": 400,
+            "chain_findings_memory": [
+                {
+                    "finding_type": "configuration_found",
+                    "severity": "low",
+                    "title": "CORS wildcard",
+                    "evidence": "Access-Control-Allow-Origin: *",
+                    "confidence": 95,
+                    "step_iteration": 2,
+                },
+            ],
+            "execution_trace": [],
+            "target_info": {},
+            "parent_target_info": {},
+            "_pending_confirmation": {"tool_name": "execute_curl"},
+        }
+        spec = {"name": "Scout", "task": "t", "tools": ["curl"]}
+        result = _timeout_result_from_snapshot(snapshot, spec, "member-0-x", 30.5)
+
+        self.assertEqual(result["status"], "timeout")
+        self.assertEqual(result["completion_reason"], "wave_timeout")
+        self.assertEqual(result["iterations_used"], 3)
+        self.assertEqual(result["tokens_used"], 2400)
+        self.assertEqual(result["input_tokens_used"], 2000)
+        self.assertEqual(result["output_tokens_used"], 400)
+        self.assertEqual(len(result["findings"]), 1)
+        self.assertEqual(result["findings"][0]["title"], "CORS wildcard")
+        # pending_confirmation suppressed: member is terminating, not awaiting.
+        self.assertIsNone(result.get("pending_confirmation"))
+
+    def test_timeout_result_from_snapshot_fallback_when_no_snapshot(self):
+        """When no snapshot is registered (member cancelled before any state
+        update), fall back to the all-zeros _timeout_result."""
+        from orchestrator_helpers.nodes.fireteam_deploy_node import (
+            _timeout_result_from_snapshot,
+        )
+        result = _timeout_result_from_snapshot(None, {"name": "Scout"}, "m-0", 1.0)
+        self.assertEqual(result["status"], "timeout")
+        self.assertEqual(result["completion_reason"], "wave_timeout")
+        self.assertEqual(result["iterations_used"], 0)
+        self.assertEqual(result["tokens_used"], 0)
+        self.assertEqual(result.get("findings") or [], [])
+
+
+# =============================================================================
+# BUG: Single try/except wrapped the whole findings-conversion loop at debug
+# level, dropping the entire batch on one bad item and hiding the failure.
+# =============================================================================
+#
+# Fix moved the try/except inside the loop (per-item isolation) and raised the
+# log level to warning so schema drift / malformed LLM emissions surface on
+# the default console handler (CONSOLE_LOG_LEVEL=INFO).
+
+
+class FindingConversionPerItemExceptionRegression(unittest.TestCase):
+    """Locks the fix: a malformed finding skips itself, not the whole batch,
+    and emits a warning-level log identifying the failure."""
+
+    def test_one_bad_finding_doesnt_drop_the_batch(self):
+        from orchestrator_helpers.nodes.fireteam_deploy_node import (
+            _result_from_final_state,
+        )
+
+        final_state = {
+            "chain_findings_memory": [
+                {
+                    "finding_type": "service_identified",
+                    "severity": "info",
+                    "title": "good 1",
+                    "evidence": "nginx 1.18 detected",
+                    "confidence": 80,
+                    "step_iteration": 1,
+                },
+                {
+                    # Pydantic v2 ValidationError: "high" can't coerce to int.
+                    "finding_type": "vulnerability_confirmed",
+                    "severity": "high",
+                    "title": "bad item — confidence is a string",
+                    "evidence": "unparseable confidence",
+                    "confidence": "high",
+                    "step_iteration": 1,
+                },
+                {
+                    "finding_type": "configuration_found",
+                    "severity": "low",
+                    "title": "good 2",
+                    "evidence": "CORS *",
+                    "confidence": 90,
+                    "step_iteration": 2,
+                },
+            ],
+            "execution_trace": [],
+            "target_info": {},
+            "parent_target_info": {},
+        }
+        spec = {"name": "Scout", "task": "t", "tools": []}
+
+        with self.assertLogs(
+            "orchestrator_helpers.nodes.fireteam_deploy_node", level="WARNING",
+        ) as cm:
+            result = _result_from_final_state(final_state, spec, "m-0", 1.0)
+
+        # Both valid findings survive — pre-fix the whole batch would be [].
+        self.assertEqual(
+            len(result["findings"]), 2,
+            f"expected 2 valid findings to survive (good 1, good 2); got "
+            f"{len(result['findings'])}: {[f.get('title') for f in result['findings']]}",
+        )
+        titles = [f["title"] for f in result["findings"]]
+        self.assertIn("good 1", titles)
+        self.assertIn("good 2", titles)
+        self.assertNotIn("bad item — confidence is a string", titles)
+
+        # A WARNING was emitted that mentions the failure. Either the offending
+        # dict's title or the Pydantic field name ('confidence') is enough.
+        joined = "\n".join(cm.output)
+        self.assertTrue(
+            "bad item" in joined or "confidence" in joined,
+            f"warning log did not surface the bad item: {joined!r}",
+        )
+
+
+# =============================================================================
+# BUG: Operator confirmation wait time consumed the wave wall-clock budget.
+# =============================================================================
+#
+# Per-member `await asyncio.wait_for(entry.event.wait(), timeout=600)` runs
+# inside the wave's outer asyncio timer. From the event loop's perspective,
+# operator delay is a normal `await` that accumulates monotonically against
+# the wave timeout. A slow operator could exhaust the wave clock entirely
+# before any tools ran.
+#
+# Fix: deadline-extension. The confirmation registry tracks wall-clock time
+# spent in operator-wait per wave (interval-union so parallel waits do not
+# double-count). The deploy node's manual deadline loop polls
+# `get_credit_s(...)` and extends its deadline by any new credit, so
+# operator-side delay no longer reduces the budget available for tools.
+
+
+def _settings_for_credit_test():
+    return lambda k, d=None: {
+        "FIRETEAM_MAX_CONCURRENT": 3,
+        "FIRETEAM_MAX_MEMBERS": 8,
+        "FIRETEAM_TIMEOUT_SEC": 2,   # short base so credit is the deciding factor
+        "FIRETEAM_MEMBER_MAX_ITERATIONS": 10,
+    }.get(k, d)
+
+
+def _credit_simulating_graph_factory(*, simulated_wait_s: float):
+    """Member graph that simulates an operator-confirmation wait by directly
+    calling the registry's begin/end_confirmation_wait helpers, then completes
+    successfully. Total wall-clock duration ~= simulated_wait_s + small work
+    bookends; without the fix the wave would time out at FIRETEAM_TIMEOUT_SEC."""
+    from orchestrator_helpers.fireteam_confirmation_registry import (
+        begin_confirmation_wait, end_confirmation_wait,
+    )
+
+    class _CreditGraph:
+        async def _run(self, s, config=None):
+            session_id = s.get("session_id") or ""
+            wave_id = s.get("fireteam_id") or ""
+            # Bookend 1: a touch of "work" so total wall > base timeout
+            await asyncio.sleep(0.1)
+            # Simulate operator confirmation wait (credited back to wave).
+            begin_confirmation_wait(session_id, wave_id)
+            try:
+                await asyncio.sleep(simulated_wait_s)
+            finally:
+                end_confirmation_wait(session_id, wave_id)
+            # Bookend 2: more "work" to consume more wall-clock past base timeout
+            await asyncio.sleep(0.5)
+            yield {
+                "fireteam_complete": {
+                    "task_complete": True,
+                    "completion_reason": "complete",
+                    "current_iteration": 1,
+                    "tokens_used": 5,
+                    "input_tokens_used": 4,
+                    "output_tokens_used": 1,
+                    "execution_trace": [],
+                    "target_info": {},
+                    "chain_findings_memory": [],
+                }
+            }
+
+        def astream(self, s, config=None):
+            return self._run(s, config)
+    return _CreditGraph()
+
+
+class WaveClockExcludesConfirmationWaitRegression(unittest.IsolatedAsyncioTestCase):
+    """Locks the fix: a long operator-confirmation wait does not consume the
+    wave wall-clock budget. With FIRETEAM_TIMEOUT_SEC=2 and a simulated 3s
+    wait, the member should still complete (pre-fix it would have been
+    cancelled when the wave clock hit 2s)."""
+
+    async def test_long_confirmation_wait_extends_wave_deadline(self):
+        from orchestrator_helpers.nodes.fireteam_deploy_node import fireteam_deploy_node
+
+        patch_member_mock = AsyncMock()
+        with patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node._persist_deploy",
+            new=AsyncMock(return_value="id"),
+        ), patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node._patch_member",
+            new=patch_member_mock,
+        ), patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node._patch_fireteam",
+            new=AsyncMock(),
+        ), patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node.get_setting",
+            side_effect=_settings_for_credit_test(),
+        ):
+            t0 = _time.monotonic()
+            await fireteam_deploy_node(
+                _parent_state(n_members=1), None,
+                member_graph=_credit_simulating_graph_factory(simulated_wait_s=3.0),
+                streaming_callbacks={},
+                neo4j_creds=None,
+            )
+            wall = _time.monotonic() - t0
+            # Total wall ≈ 0.1 + 3.0 + 0.5 = 3.6s. Base timeout was 2s; without
+            # the fix the wave would have timed out around 2s. Assert wall > 3s
+            # so we know the wait actually happened (not skipped/raced).
+            self.assertGreater(
+                wall, 3.0,
+                f"wave finished suspiciously fast ({wall:.2f}s) — confirmation "
+                f"wait may have been skipped",
+            )
+            # And bounded — wall should be < 6s (sanity); if it's hitting a
+            # 1800/7200s default the test infra is misconfigured.
+            self.assertLess(wall, 6.0, f"wave took too long: {wall:.2f}s")
+
+        # Find the final patch per member. Pre-fix this would be status=timeout
+        # because the wave clock ran out before the member yielded its complete
+        # event. Post-fix the deadline was extended by the simulated wait, so
+        # the member completes successfully.
+        self.assertGreater(len(patch_member_mock.call_args_list), 0)
+        last_body = patch_member_mock.call_args_list[-1].args[3]
+        self.assertEqual(
+            last_body["status"], "success",
+            f"member should have completed successfully (operator wait was "
+            f"credited back); got status={last_body.get('status')!r}, "
+            f"completionReason={last_body.get('completionReason')!r}",
+        )
+
+    def test_credit_accumulator_interval_union_semantics(self):
+        """Unit test for the registry's interval-union behavior: two parallel
+        waits credit only their wall-clock overlap, not their sum."""
+        import time as _t
+        from orchestrator_helpers.fireteam_confirmation_registry import (
+            begin_confirmation_wait, end_confirmation_wait,
+            get_credit_s, drop_wave_credit,
+        )
+
+        session_id = "test-session-iu"
+        wave_id = "test-wave-iu"
+        drop_wave_credit(session_id, wave_id)  # ensure clean slate
+
+        # Member A starts waiting.
+        begin_confirmation_wait(session_id, wave_id)
+        _t.sleep(0.2)
+        # Member B starts waiting WHILE A is still waiting (parallel).
+        begin_confirmation_wait(session_id, wave_id)
+        _t.sleep(0.2)
+        # Member A finishes; B still waiting (count goes 2→1, no commit yet).
+        end_confirmation_wait(session_id, wave_id)
+        _t.sleep(0.2)
+        # Member B finishes; count goes 1→0, commit total elapsed pause.
+        end_confirmation_wait(session_id, wave_id)
+
+        credit = get_credit_s(session_id, wave_id)
+        # Wall-clock pause = ~0.6s (A's start through B's end).
+        # Simple sum would be ~0.4 + 0.4 = 0.8s — wrong.
+        # Interval-union gives ~0.6s — right.
+        self.assertGreater(credit, 0.5, f"credit too low: {credit:.3f}")
+        self.assertLess(credit, 0.75,
+                        f"credit too high (simple-sum bug?): {credit:.3f}")
+        drop_wave_credit(session_id, wave_id)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/readmes/README.AGENTIC_SYSTEM.md
+++ b/readmes/README.AGENTIC_SYSTEM.md
@@ -2098,7 +2098,7 @@ The proxy MUST forward `wave_id` and `step_index` for every `on_tool_*` call. If
 | Trigger | Behavior |
 |---|---|
 | Operator clicks Stop | parent task cancel -> `fireteam_deploy_node` catches `CancelledError` -> `drop_wave(session, wave)` wakes pending Events with reject -> `task.cancel()` on each member -> members exit -> wave marked `cancelled` |
-| Wave wall-clock timeout (`FIRETEAM_TIMEOUT_SEC`, default 1800s) | `asyncio.wait_for` on the gather raises `TimeoutError` -> same cleanup path as cancel; status `timeout` |
+| Wave wall-clock timeout (`FIRETEAM_TIMEOUT_SEC`, default 7200s) | Deploy node's deadline loop raises `TimeoutError` -> same cleanup path as cancel; status `timeout`. Time spent awaiting operator confirmation is credited back to the wave deadline, so slow approvals do not consume the wall-clock budget. |
 | Member exceeds iteration budget (`FIRETEAM_MEMBER_MAX_ITERATIONS`) | member exits with status `partial`, findings preserved |
 | Operator never decides a confirmation | member's own `asyncio.wait_for(event.wait(), 600s)` -> `TimeoutError` -> treated as reject with a distinctive note |
 | Single member crashes | `return_exceptions=True` on gather -> that member gets `status=error` + `error_message`, wave completes normally |
@@ -2207,7 +2207,7 @@ Mapped from Prisma `Project.*` fields into the agent's `FIRETEAM_*` settings on 
 | `FIRETEAM_MAX_CONCURRENT` | `5` | `asyncio.Semaphore` permits during a wave |
 | `FIRETEAM_MAX_MEMBERS` | `5` | Hard cap on members per wave |
 | `FIRETEAM_MEMBER_MAX_ITERATIONS` | `20` | Per-member ReAct iteration budget |
-| `FIRETEAM_TIMEOUT_SEC` | `1800` | Wall-clock ceiling per wave |
+| `FIRETEAM_TIMEOUT_SEC` | `7200` | Wall-clock ceiling per wave (operator-confirmation waits are credited back, so they do not consume this budget) |
 | `FIRETEAM_CONFIRMATION_TIMEOUT_SEC` | `600` | Per-member confirmation wait before auto-reject |
 | `FIRETEAM_ALLOWED_PHASES` | `[informational, exploitation, post_exploitation]` | Phases in which the agent may deploy a fireteam |
 
@@ -4077,7 +4077,7 @@ flowchart LR
 | `FIRETEAM_MAX_CONCURRENT` | `5` | `asyncio.Semaphore` permits during a wave |
 | `FIRETEAM_MAX_MEMBERS` | `5` | Hard cap on members per wave |
 | `FIRETEAM_MEMBER_MAX_ITERATIONS` | `20` | Per-member ReAct iteration budget |
-| `FIRETEAM_TIMEOUT_SEC` | `1800` | Wall-clock ceiling per wave (gather timeout) |
+| `FIRETEAM_TIMEOUT_SEC` | `7200` | Wall-clock ceiling per wave (deadline loop; operator-confirmation waits are credited back so they do not consume this budget) |
 | `FIRETEAM_CONFIRMATION_TIMEOUT_SEC` | `600` | Per-member confirmation wait before auto-reject |
 | `FIRETEAM_ALLOWED_PHASES` | `["informational","exploitation","post_exploitation"]` | Phases in which the agent may deploy a fireteam |
 | `INFORMATIONAL_SYSTEM_PROMPT` | `""` | Custom system prompt injected during informational phase |


### PR DESCRIPTION
> **Depends on #117.** Please review and merge #117 first; once that merges, this PR's diff will auto-reduce to contain only the wave-clock changes (the second of two commits on this branch).


### Summary

A fireteam wave's wall-clock timer was consumed by operator confirmation waits. A slow operator could exhaust the wave budget before any tools ran. The fix tracks confirmation-wait time per wave (interval-union semantics for parallel waits) and extends the wave's deadline by that credit, so operator-side delay no longer reduces the budget available for tool execution. Three inconsistent `FIRETEAM_TIMEOUT_SEC` defaults across code and docs are reconciled to a single value (7200).

### Problem

The per-member confirmation wait at `agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py:113-114` (`await asyncio.wait_for(entry.event.wait(), timeout=FIRETEAM_CONFIRMATION_TIMEOUT_SEC)`) runs inside the wave's outer `asyncio.wait_for(asyncio.gather(...), timeout=FIRETEAM_TIMEOUT_SEC)` at `agentic/orchestrator_helpers/nodes/fireteam_deploy_node.py:725-727`. From the event loop's perspective, the operator's delay is a normal `await` that accumulates monotonically against the outer timer. Empirically, a single wave was observed consuming ~40min of operator-wait inside its 3600s budget before tools ran.

The documented intent of each clock points away from coupling them. `FIRETEAM_TIMEOUT_SEC`'s comment (`agentic/project_settings.py:60`) sizes it for "30-min tool timeouts" — a tool-execution bound. `FIRETEAM_CONFIRMATION_TIMEOUT_SEC`'s comment (`agentic/project_settings.py:62`) describes it as an anti-hang safety net for "walked-away operator". Neither comment, nor any test or doc, frames the 600s as the operator's fair share of the wave budget. The UI also carries no countdown or `wave_remaining_seconds` in the confirmation websocket payload, so an operator literally cannot see the clock they're consuming.

Sub-issue: three inconsistent defaults for `FIRETEAM_TIMEOUT_SEC` — `agentic/project_settings.py:60` = 7200 (the operator-facing canonical value with comment justifying it), `agentic/orchestrator_helpers/nodes/fireteam_deploy_node.py:525` get_setting fallback = 1800, README references at lines 2101 / 2210 / 4080 = 1800.

### Fix

Five files modified.

**`agentic/orchestrator_helpers/fireteam_confirmation_registry.py`** — Added wave-clock credit tracking using interval-union semantics so two members waiting in parallel for 60s credit the wave 60s of pause (not 120s). Three module-level dicts: `_WAVE_ACTIVE_WAITS` (count of currently-waiting members per wave), `_WAVE_PAUSE_START` (monotonic timestamp when the count went 0→1), `_WAVE_CREDIT_S` (accumulated paused-interval time). Four new helpers: `begin_confirmation_wait(session_id, wave_id)` (increment count, start pause clock on 0→1), `end_confirmation_wait(session_id, wave_id)` (decrement; commit elapsed on 1→0), `get_credit_s(session_id, wave_id) -> float` (returns accumulated credit including any in-progress pause), `drop_wave_credit(session_id, wave_id)` (teardown).

**`agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py`** — In `fireteam_await_confirmation_node`, wrapped the `await asyncio.wait_for(entry.event.wait(), ...)` with `begin_confirmation_wait` / `end_confirmation_wait` via `try / finally`. The `finally` placement guarantees the count balances even on `TimeoutError` or `CancelledError`; without it, a cancelled wait would leave the wave clock stuck-paused.

**`agentic/orchestrator_helpers/nodes/fireteam_deploy_node.py`** — Replaced `asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), timeout=timeout_s)` with a manual deadline-extension loop. At each tick the loop polls `get_credit_s(...)` for any new credit and extends `deadline` accordingly, then `asyncio.wait(pending, timeout=min(remaining, 1.0))` advances the task set. On timeout it raises `asyncio.TimeoutError` so the existing timeout-handler branch (cancellation cleanup, snapshot recovery, per-member patch) runs unchanged. The 1-second poll cap ensures credit changes are picked up promptly (overhead: ~7200 wakes per 2hr wave; negligible). Also: updated `get_setting("FIRETEAM_TIMEOUT_SEC", 1800)` fallback to `7200` to match `project_settings.py`. Added `drop_wave_credit(session_id, fireteam_id_key)` to wave teardown alongside the existing `drop_wave` on the timeout, operator-cancel, and normal-completion paths.

**`readmes/README.AGENTIC_SYSTEM.md`** — Updated three `FIRETEAM_TIMEOUT_SEC` references (lines 2101 / 2210 / 4080) from `1800s` to `7200s`. Two of them now also note that operator-confirmation waits are credited back to the wave deadline.

**`agentic/tests/test_fireteam_regressions.py`** — Added `WaveClockExcludesConfirmationWaitRegression` with two tests:
- `test_long_confirmation_wait_extends_wave_deadline` — an integration test using a new `_credit_simulating_graph_factory` that directly calls `begin_confirmation_wait` / `end_confirmation_wait` from inside its astream loop to simulate an operator wait. With `FIRETEAM_TIMEOUT_SEC=2` and a 3s simulated wait, the member completes successfully and `_patch_member` is called with `status="success"`. Pre-fix, the wave would have timed out at 2s and the member would have been cancelled.
- `test_credit_accumulator_interval_union_semantics` — a unit test that overlaps two waits (A starts, B starts, A ends, B ends) and asserts the credited time matches the union interval (~0.6s) rather than the sum (~0.8s). Pins the parallel-waits semantic that's the main subtle correctness point of the design.

### Testing

Both static and dynamic. Five files parse cleanly; two new tests pass in the agent container; all 8 neighboring fireteam-regression tests (wave-timeout DB persist, in-flight-state preservation, websocket emit, per-item finding conversion) still pass — no regressions.

Runtime testing with a real fireteam wave plus a real operator was impractical for the usual reasons (agent container bakes source at build time rather than bind-mounting it; triggering the bug end-to-end needs a UI-driven repro with a deliberately slow operator). The test-based dynamic verification covers the structural contract directly: the integration test pins the load-bearing claim (slow operator → member still completes), and the unit test pins the interval-union semantics that simple-sum would get wrong on parallel waits.

### Risk

Medium. This replaces a load-bearing `asyncio.wait_for(gather)` pattern with a manual deadline loop, which is structurally different even though the externally-visible semantics are preserved for the no-confirmation case.

Watch-out for reviewers:

- **Polling overhead.** The deadline loop's `asyncio.wait(pending, timeout=min(remaining, 1.0))` polls at 1Hz when no tasks complete. For a 2-hour wave with no completions this is ~7200 wakes; each wake reads three dict entries from the registry. Negligible CPU cost compared to LLM work; mention if you want it pushed to a higher granularity (5s, 10s) — the trade-off is just credit-application latency.
- **Cancellation balance is load-bearing for correctness.** The member's `try / finally` around `begin_confirmation_wait` / `end_confirmation_wait` is what guarantees the wave clock doesn't stay-paused after a cancellation. If a future maintainer rearranges this, the test `test_long_confirmation_wait_extends_wave_deadline` would still pass (its happy-path doesn't cancel mid-wait), but a real cancellation could leak. Worth either adding a cancellation-mid-wait test or commenting the invariant strongly.
- **Per-session test isolation.** The registry's module-level dicts are shared process-wide. The unit test calls `drop_wave_credit` at the start to clear any leftover state, but if multiple tests run in parallel against the same `(session_id, wave_id)` they'd interfere. The current test fixtures use distinct session_ids (`s-timeout` for wave-timeout tests, `s` from `_parent_state`, `test-session-iu` for the unit test) so there's no collision today. Worth a comment for future maintainers.
- **`FIRETEAM_TIMEOUT_SEC` default raised from 1800 → 7200.** Operators relying on the `get_setting` fallback (no explicit setting) now get a 4× longer wave timeout. The verdict notes 7200 is the canonical value declared in `project_settings.py` with a stated rationale; the 1800 in fallback and README was stale residue. Backward-compatible for any deployment that explicitly sets `FIRETEAM_TIMEOUT_SEC`. No schema change.
- **Interval-union vs simple-sum.** The interval-union model is the structurally correct one — but a maintainer could argue "simple sum is conservative, gives more time, lower risk". Worth flagging in PR review. Test pins interval-union; if maintainer prefers simple-sum, that's a one-line registry change and the test updates accordingly.

Backward-compatibility: the externally-visible wave-timeout semantics are unchanged for any wave that doesn't hit operator confirmation. The wave still times out when tool work alone exceeds budget. No DB / API / message-shape changes.

---

