### PR TITLE
fix(fireteam): preserve tool output in member local-progress trace across iterations

### DIFF
--- a/agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py
+++ b/agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py
@@ -1100,54 +1100,6 @@ async def fireteam_member_think_node(
     # defining it here, the is_dangerous branch crashed with NameError.
     analysis = decision.output_analysis
 
-    if is_dangerous:
-        pending = _build_pending_confirmation(decision, state)
-        update["_pending_confirmation"] = pending
-        # FIX: Populate _current_plan / _current_step now so they survive
-        # the await round-trip. Without this, the await node returns to
-        # the router with these fields unset and the router falls back to
-        # fireteam_think -> infinite plan/approve loop, no tool execution.
-        if decision.action == "plan_tools" and decision.tool_plan:
-            update["_current_plan"] = decision.tool_plan.model_dump()
-        elif decision.action == "use_tool":
-            update["_current_step"] = {
-                "step_id": uuid4().hex,
-                "iteration": current_iter + 1,
-                "phase": state.get("current_phase"),
-                "tool_name": decision.tool_name,
-                "tool_args": decision.tool_args or {},
-                "thought": decision.thought,
-                "reasoning": decision.reasoning,
-            }
-        # Even though we're escalating the NEW decision, the PREVIOUS
-        # single-tool step (if any) is now completed — its output was the
-        # input to this think call. Signal it to the streaming layer so the
-        # UI flips the prior tool card from `running` to `success/error`.
-        # Without this, the frontend sees: tool_start → (never completes) →
-        # pending-approval card, and the prior tool stays stuck visually.
-        if has_pending_single_output and prev_step:
-            completed_prev = dict(prev_step)
-            if analysis is not None:
-                completed_prev["output_analysis"] = (
-                    analysis.interpretation
-                    or (prev_step.get("tool_output") or "")
-                )[:20000]
-                completed_prev["actionable_findings"] = list(analysis.actionable_findings or [])
-                completed_prev["recommended_next_steps"] = list(analysis.recommended_next_steps or [])
-            else:
-                completed_prev["output_analysis"] = (prev_step.get("tool_output") or "")[:20000]
-                completed_prev["actionable_findings"] = []
-                completed_prev["recommended_next_steps"] = []
-            update["_completed_step"] = completed_prev
-        logger.info(
-            "[%s] member %s escalating dangerous tool for parent approval: %s",
-            session_id, member_id,
-            decision.tool_name or [s.tool_name for s in (decision.tool_plan.steps if decision.tool_plan else [])],
-        )
-        # Router will send us to fireteam_await_confirmation because
-        # _pending_confirmation is set.
-        return update
-
     # If action is complete, ensure task_complete is True so the router exits.
     if decision.action == "complete":
         update["task_complete"] = True
@@ -1499,5 +1451,55 @@ async def fireteam_member_think_node(
             pass  # update["_current_plan"] already set to the new plan above
         else:
             update["_current_plan"] = None
+
+    # Dangerous-tool escalation runs AFTER analysis-write so the prior wave's
+    # chain_findings, target_info merge, and Neo4j writes commit before we
+    # pause for operator approval. `_pending_confirmation` is the router's
+    # signal to fireteam_await_confirmation — its placement in this function
+    # does not affect routing, only whether analysis-write fires first.
+    if is_dangerous:
+        pending = _build_pending_confirmation(decision, state)
+        update["_pending_confirmation"] = pending
+        # Populate _current_plan / _current_step so they survive the await
+        # round-trip. Without this, the await node returns to the router
+        # with these fields unset and the router falls back to fireteam_think
+        # -> infinite plan/approve loop, no tool execution.
+        if decision.action == "plan_tools" and decision.tool_plan:
+            update["_current_plan"] = decision.tool_plan.model_dump()
+        elif decision.action == "use_tool":
+            update["_current_step"] = {
+                "step_id": uuid4().hex,
+                "iteration": current_iter + 1,
+                "phase": state.get("current_phase"),
+                "tool_name": decision.tool_name,
+                "tool_args": decision.tool_args or {},
+                "thought": decision.thought,
+                "reasoning": decision.reasoning,
+            }
+        # Even though we're escalating the NEW decision, the PREVIOUS
+        # single-tool step (if any) is now completed — its output was the
+        # input to this think call. Signal it to the streaming layer so the
+        # UI flips the prior tool card from `running` to `success/error`.
+        # Without this, the frontend sees: tool_start → (never completes) →
+        # pending-approval card, and the prior tool stays stuck visually.
+        if has_pending_single_output and prev_step:
+            completed_prev = dict(prev_step)
+            if analysis is not None:
+                completed_prev["output_analysis"] = (
+                    analysis.interpretation
+                    or (prev_step.get("tool_output") or "")
+                )[:20000]
+                completed_prev["actionable_findings"] = list(analysis.actionable_findings or [])
+                completed_prev["recommended_next_steps"] = list(analysis.recommended_next_steps or [])
+            else:
+                completed_prev["output_analysis"] = (prev_step.get("tool_output") or "")[:20000]
+                completed_prev["actionable_findings"] = []
+                completed_prev["recommended_next_steps"] = []
+            update["_completed_step"] = completed_prev
+        logger.info(
+            "[%s] member %s escalating dangerous tool for parent approval: %s",
+            session_id, member_id,
+            decision.tool_name or [s.tool_name for s in (decision.tool_plan.steps if decision.tool_plan else [])],
+        )
 
     return update

--- a/agentic/state.py
+++ b/agentic/state.py
@@ -1314,6 +1314,19 @@ def format_chain_context(
                 else:
                     tool_name = tools[0].get("tool_name") or "none"
                     lines.append(f"  {it} [{phase}]: {tool_name} ->{fail_marker} {analysis[:10000]}")
+                # Tool digest: name + short args per tool, joined. Gives the
+                # Self-Check duplicate-target rule something to match on for
+                # iterations beyond the recent window — without this, only
+                # the LLM's own analysis text survives, and identical tool
+                # calls become invisible to the duplicate detector.
+                digest_parts = []
+                for t in tools:
+                    tname = t.get("tool_name") or "unknown"
+                    targs = t.get("tool_args") or {}
+                    args_str = str(targs)[:80] if targs else ""
+                    digest_parts.append(f"{tname}({args_str})" if args_str else tname)
+                if digest_parts:
+                    lines.append(f"      tools: {'; '.join(digest_parts)}")
             lines.append("")
 
         if total_iterations > recent_iterations:
@@ -1341,7 +1354,12 @@ def format_chain_context(
                 ok_count = 0
                 fail_count = 0
                 failed_tools: list = []
-                tool_args_list: list = []
+                # Per-tool entries carry (args_line, output_preview). The
+                # output preview is what the Self-Check duplicate-target rule
+                # uses to recognize "I already ran this and got the same
+                # answer", so retain it across iterations rather than only on
+                # the very last shown tool.
+                tool_entries: list = []
                 for t in tools:
                     tname = t.get("tool_name") or "unknown"
                     tool_counts[tname] = tool_counts.get(tname, 0) + 1
@@ -1354,9 +1372,13 @@ def format_chain_context(
                         )
                     targs = t.get("tool_args") or {}
                     if targs:
-                        tool_args_list.append(
-                            f"    - {tname}: {str(targs)[:300]}"
-                        )
+                        args_line = f"    - {tname}: {str(targs)[:300]}"
+                        preview = ""
+                        if t.get("success", True):
+                            raw = (t.get("tool_output") or t.get("output_summary") or "")
+                            if raw:
+                                preview = str(raw).replace("\n", " ")[:200]
+                        tool_entries.append((args_line, preview))
 
                 tool_summary = ", ".join(
                     f"{cnt} {name}" for name, cnt in tool_counts.items()
@@ -1377,11 +1399,17 @@ def format_chain_context(
                 if rationale:
                     lines.append(f"    Rationale: {rationale[:400]}")
 
-                # Individual tool args (compact, one line each)
-                if tool_args_list:
+                # Individual tool args + short output preview. The preview
+                # is the load-bearing addition: without it the LLM at
+                # iteration N can spot identical tool args from iter N-1
+                # only by guessing; with it the LLM sees the actual result
+                # shape and won't re-run the same probe.
+                if tool_entries:
                     lines.append("    Tools:")
-                    for arg_line in tool_args_list:
-                        lines.append(arg_line)
+                    for args_line, preview in tool_entries:
+                        lines.append(args_line)
+                        if preview:
+                            lines.append(f"      → {preview}")
 
                 # Failures
                 for ft in failed_tools:
@@ -1412,6 +1440,15 @@ def format_chain_context(
                         lines.append(f"    OK | {out_preview}")
                     else:
                         lines.append(f"    OK")
+                    # When both analysis AND raw output are present, the OK
+                    # line above shadowed raw output behind the LLM's
+                    # summary. Surface a short raw-output preview separately
+                    # so the duplicate-target rule has the actual response
+                    # to match on, not just the LLM's interpretation.
+                    if analysis and output:
+                        raw_preview = str(output).replace("\n", " ")[:300]
+                        if raw_preview:
+                            lines.append(f"    Raw: {raw_preview}")
                 else:
                     lines.append(f"    FAILED | {err[:300]}")
 

--- a/agentic/tests/test_fireteam_regressions.py
+++ b/agentic/tests/test_fireteam_regressions.py
@@ -605,5 +605,579 @@ class WaveTimeoutWebsocketEmitRegression(unittest.IsolatedAsyncioTestCase):
                              f"per-member emit must carry status=timeout; got {call.kwargs}")
 
 
+# =============================================================================
+# BUG: Wave-timeout reported zero counters / no findings for productive members.
+# =============================================================================
+#
+# When FIRETEAM_TIMEOUT_SEC fires while a member is mid-execution, the closure-
+# local ``final_state`` inside ``_run_one`` is GC'd at cancellation, and the
+# outer timeout handler built ``_timeout_result(spec, mid, wall_s)`` which
+# hardcoded iterations_used=0, tokens_used=0 and defaulted findings=[]. Those
+# zeros were PATCHed to Postgres and propagated to the UI.
+#
+# Fix: snapshot-by-reference. ``_run_one`` registers a reference to its
+# ``final_state`` in an outer-scope ``member_snapshots`` dict; the in-place
+# ``.update(node_update)`` mutations in the astream loop keep the reference
+# current. The timeout handler reads from that map via
+# ``_timeout_result_from_snapshot`` (which reuses ``_result_from_final_state``
+# and overrides status/completion_reason).
+
+
+def _mid_flight_graph_factory(
+    *,
+    iterations_used: int = 2,
+    input_tokens: int = 1500,
+    output_tokens: int = 300,
+    findings: list | None = None,
+    delay_s: float = 5.0,
+):
+    """Member graph that yields a productive in-flight state update once,
+    then sleeps past the wave timeout. Simulates a member that did real work
+    before being cancelled by the outer wave-timeout handler."""
+    if findings is None:
+        findings = [{
+            "finding_type": "service_identified",
+            "severity": "info",
+            "title": "nginx 1.18 banner",
+            "evidence": "Server: nginx/1.18",
+            "confidence": 100,
+            "step_iteration": 1,
+        }]
+
+    class _MidFlightGraph:
+        async def _run(self, s, config=None):
+            yield {
+                "fireteam_think": {
+                    "current_iteration": iterations_used,
+                    "tokens_used": input_tokens + output_tokens,
+                    "input_tokens_used": input_tokens,
+                    "output_tokens_used": output_tokens,
+                    "chain_findings_memory": list(findings),
+                    "execution_trace": [],
+                    "target_info": {},
+                }
+            }
+            await asyncio.sleep(delay_s)
+
+        def astream(self, s, config=None):
+            return self._run(s, config)
+    return _MidFlightGraph()
+
+
+class WaveTimeoutPreservesPartialStateRegression(unittest.IsolatedAsyncioTestCase):
+    """Locks the fix: cancelled members surface real iter/token/findings
+    counts from their in-flight final_state rather than all-zeros."""
+
+    async def test_patch_body_carries_in_flight_iterations_and_tokens(self):
+        from orchestrator_helpers.nodes.fireteam_deploy_node import fireteam_deploy_node
+
+        patch_member_mock = AsyncMock()
+        with patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node._persist_deploy",
+            new=AsyncMock(return_value="id"),
+        ), patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node._patch_member",
+            new=patch_member_mock,
+        ), patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node._patch_fireteam",
+            new=AsyncMock(),
+        ), patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node.get_setting",
+            side_effect=_settings_for_timeout_test(),
+        ):
+            await fireteam_deploy_node(
+                _parent_state(n_members=1), None,
+                member_graph=_mid_flight_graph_factory(
+                    iterations_used=2,
+                    input_tokens=1500,
+                    output_tokens=300,
+                ),
+                streaming_callbacks={},
+                neo4j_creds=None,
+            )
+
+        self.assertGreater(len(patch_member_mock.call_args_list), 0,
+                           "no _patch_member calls — DB never updated")
+        last_body = patch_member_mock.call_args_list[-1].args[3]
+        self.assertEqual(last_body["status"], "timeout")
+        self.assertEqual(last_body["completionReason"], "wave_timeout")
+        self.assertEqual(
+            last_body["iterationsUsed"], 2,
+            f"expected real iterationsUsed=2 from in-flight snapshot, "
+            f"got {last_body.get('iterationsUsed')}",
+        )
+        self.assertEqual(
+            last_body["tokensUsed"], 1800,
+            f"expected real tokensUsed=1800 (1500+300), "
+            f"got {last_body.get('tokensUsed')}",
+        )
+        self.assertEqual(
+            last_body["findingsCount"], 1,
+            f"expected findingsCount=1 from in-flight chain_findings_memory, "
+            f"got {last_body.get('findingsCount')}",
+        )
+
+    def test_timeout_result_from_snapshot_with_populated_state(self):
+        """Unit test for the helper: populated snapshot → real counts +
+        timeout labels."""
+        from orchestrator_helpers.nodes.fireteam_deploy_node import (
+            _timeout_result_from_snapshot,
+        )
+
+        snapshot = {
+            "current_iteration": 3,
+            "tokens_used": 2400,
+            "input_tokens_used": 2000,
+            "output_tokens_used": 400,
+            "chain_findings_memory": [
+                {
+                    "finding_type": "configuration_found",
+                    "severity": "low",
+                    "title": "CORS wildcard",
+                    "evidence": "Access-Control-Allow-Origin: *",
+                    "confidence": 95,
+                    "step_iteration": 2,
+                },
+            ],
+            "execution_trace": [],
+            "target_info": {},
+            "parent_target_info": {},
+            "_pending_confirmation": {"tool_name": "execute_curl"},
+        }
+        spec = {"name": "Scout", "task": "t", "tools": ["curl"]}
+        result = _timeout_result_from_snapshot(snapshot, spec, "member-0-x", 30.5)
+
+        self.assertEqual(result["status"], "timeout")
+        self.assertEqual(result["completion_reason"], "wave_timeout")
+        self.assertEqual(result["iterations_used"], 3)
+        self.assertEqual(result["tokens_used"], 2400)
+        self.assertEqual(result["input_tokens_used"], 2000)
+        self.assertEqual(result["output_tokens_used"], 400)
+        self.assertEqual(len(result["findings"]), 1)
+        self.assertEqual(result["findings"][0]["title"], "CORS wildcard")
+        # pending_confirmation suppressed: member is terminating, not awaiting.
+        self.assertIsNone(result.get("pending_confirmation"))
+
+    def test_timeout_result_from_snapshot_fallback_when_no_snapshot(self):
+        """When no snapshot is registered (member cancelled before any state
+        update), fall back to the all-zeros _timeout_result."""
+        from orchestrator_helpers.nodes.fireteam_deploy_node import (
+            _timeout_result_from_snapshot,
+        )
+        result = _timeout_result_from_snapshot(None, {"name": "Scout"}, "m-0", 1.0)
+        self.assertEqual(result["status"], "timeout")
+        self.assertEqual(result["completion_reason"], "wave_timeout")
+        self.assertEqual(result["iterations_used"], 0)
+        self.assertEqual(result["tokens_used"], 0)
+        self.assertEqual(result.get("findings") or [], [])
+
+
+# =============================================================================
+# BUG: Single try/except wrapped the whole findings-conversion loop at debug
+# level, dropping the entire batch on one bad item and hiding the failure.
+# =============================================================================
+#
+# Fix moved the try/except inside the loop (per-item isolation) and raised the
+# log level to warning so schema drift / malformed LLM emissions surface on
+# the default console handler (CONSOLE_LOG_LEVEL=INFO).
+
+
+class FindingConversionPerItemExceptionRegression(unittest.TestCase):
+    """Locks the fix: a malformed finding skips itself, not the whole batch,
+    and emits a warning-level log identifying the failure."""
+
+    def test_one_bad_finding_doesnt_drop_the_batch(self):
+        from orchestrator_helpers.nodes.fireteam_deploy_node import (
+            _result_from_final_state,
+        )
+
+        final_state = {
+            "chain_findings_memory": [
+                {
+                    "finding_type": "service_identified",
+                    "severity": "info",
+                    "title": "good 1",
+                    "evidence": "nginx 1.18 detected",
+                    "confidence": 80,
+                    "step_iteration": 1,
+                },
+                {
+                    # Pydantic v2 ValidationError: "high" can't coerce to int.
+                    "finding_type": "vulnerability_confirmed",
+                    "severity": "high",
+                    "title": "bad item — confidence is a string",
+                    "evidence": "unparseable confidence",
+                    "confidence": "high",
+                    "step_iteration": 1,
+                },
+                {
+                    "finding_type": "configuration_found",
+                    "severity": "low",
+                    "title": "good 2",
+                    "evidence": "CORS *",
+                    "confidence": 90,
+                    "step_iteration": 2,
+                },
+            ],
+            "execution_trace": [],
+            "target_info": {},
+            "parent_target_info": {},
+        }
+        spec = {"name": "Scout", "task": "t", "tools": []}
+
+        with self.assertLogs(
+            "orchestrator_helpers.nodes.fireteam_deploy_node", level="WARNING",
+        ) as cm:
+            result = _result_from_final_state(final_state, spec, "m-0", 1.0)
+
+        # Both valid findings survive — pre-fix the whole batch would be [].
+        self.assertEqual(
+            len(result["findings"]), 2,
+            f"expected 2 valid findings to survive (good 1, good 2); got "
+            f"{len(result['findings'])}: {[f.get('title') for f in result['findings']]}",
+        )
+        titles = [f["title"] for f in result["findings"]]
+        self.assertIn("good 1", titles)
+        self.assertIn("good 2", titles)
+        self.assertNotIn("bad item — confidence is a string", titles)
+
+        # A WARNING was emitted that mentions the failure. Either the offending
+        # dict's title or the Pydantic field name ('confidence') is enough.
+        joined = "\n".join(cm.output)
+        self.assertTrue(
+            "bad item" in joined or "confidence" in joined,
+            f"warning log did not surface the bad item: {joined!r}",
+        )
+
+
+# =============================================================================
+# BUG: Operator confirmation wait time consumed the wave wall-clock budget.
+# =============================================================================
+#
+# Per-member `await asyncio.wait_for(entry.event.wait(), timeout=600)` runs
+# inside the wave's outer asyncio timer. From the event loop's perspective,
+# operator delay is a normal `await` that accumulates monotonically against
+# the wave timeout. A slow operator could exhaust the wave clock entirely
+# before any tools ran.
+#
+# Fix: deadline-extension. The confirmation registry tracks wall-clock time
+# spent in operator-wait per wave (interval-union so parallel waits do not
+# double-count). The deploy node's manual deadline loop polls
+# `get_credit_s(...)` and extends its deadline by any new credit, so
+# operator-side delay no longer reduces the budget available for tools.
+
+
+def _settings_for_credit_test():
+    return lambda k, d=None: {
+        "FIRETEAM_MAX_CONCURRENT": 3,
+        "FIRETEAM_MAX_MEMBERS": 8,
+        "FIRETEAM_TIMEOUT_SEC": 2,   # short base so credit is the deciding factor
+        "FIRETEAM_MEMBER_MAX_ITERATIONS": 10,
+    }.get(k, d)
+
+
+def _credit_simulating_graph_factory(*, simulated_wait_s: float):
+    """Member graph that simulates an operator-confirmation wait by directly
+    calling the registry's begin/end_confirmation_wait helpers, then completes
+    successfully. Total wall-clock duration ~= simulated_wait_s + small work
+    bookends; without the fix the wave would time out at FIRETEAM_TIMEOUT_SEC."""
+    from orchestrator_helpers.fireteam_confirmation_registry import (
+        begin_confirmation_wait, end_confirmation_wait,
+    )
+
+    class _CreditGraph:
+        async def _run(self, s, config=None):
+            session_id = s.get("session_id") or ""
+            wave_id = s.get("fireteam_id") or ""
+            # Bookend 1: a touch of "work" so total wall > base timeout
+            await asyncio.sleep(0.1)
+            # Simulate operator confirmation wait (credited back to wave).
+            begin_confirmation_wait(session_id, wave_id)
+            try:
+                await asyncio.sleep(simulated_wait_s)
+            finally:
+                end_confirmation_wait(session_id, wave_id)
+            # Bookend 2: more "work" to consume more wall-clock past base timeout
+            await asyncio.sleep(0.5)
+            yield {
+                "fireteam_complete": {
+                    "task_complete": True,
+                    "completion_reason": "complete",
+                    "current_iteration": 1,
+                    "tokens_used": 5,
+                    "input_tokens_used": 4,
+                    "output_tokens_used": 1,
+                    "execution_trace": [],
+                    "target_info": {},
+                    "chain_findings_memory": [],
+                }
+            }
+
+        def astream(self, s, config=None):
+            return self._run(s, config)
+    return _CreditGraph()
+
+
+class WaveClockExcludesConfirmationWaitRegression(unittest.IsolatedAsyncioTestCase):
+    """Locks the fix: a long operator-confirmation wait does not consume the
+    wave wall-clock budget. With FIRETEAM_TIMEOUT_SEC=2 and a simulated 3s
+    wait, the member should still complete (pre-fix it would have been
+    cancelled when the wave clock hit 2s)."""
+
+    async def test_long_confirmation_wait_extends_wave_deadline(self):
+        from orchestrator_helpers.nodes.fireteam_deploy_node import fireteam_deploy_node
+
+        patch_member_mock = AsyncMock()
+        with patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node._persist_deploy",
+            new=AsyncMock(return_value="id"),
+        ), patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node._patch_member",
+            new=patch_member_mock,
+        ), patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node._patch_fireteam",
+            new=AsyncMock(),
+        ), patch(
+            "orchestrator_helpers.nodes.fireteam_deploy_node.get_setting",
+            side_effect=_settings_for_credit_test(),
+        ):
+            t0 = _time.monotonic()
+            await fireteam_deploy_node(
+                _parent_state(n_members=1), None,
+                member_graph=_credit_simulating_graph_factory(simulated_wait_s=3.0),
+                streaming_callbacks={},
+                neo4j_creds=None,
+            )
+            wall = _time.monotonic() - t0
+            # Total wall ≈ 0.1 + 3.0 + 0.5 = 3.6s. Base timeout was 2s; without
+            # the fix the wave would have timed out around 2s. Assert wall > 3s
+            # so we know the wait actually happened (not skipped/raced).
+            self.assertGreater(
+                wall, 3.0,
+                f"wave finished suspiciously fast ({wall:.2f}s) — confirmation "
+                f"wait may have been skipped",
+            )
+            # And bounded — wall should be < 6s (sanity); if it's hitting a
+            # 1800/7200s default the test infra is misconfigured.
+            self.assertLess(wall, 6.0, f"wave took too long: {wall:.2f}s")
+
+        # Find the final patch per member. Pre-fix this would be status=timeout
+        # because the wave clock ran out before the member yielded its complete
+        # event. Post-fix the deadline was extended by the simulated wait, so
+        # the member completes successfully.
+        self.assertGreater(len(patch_member_mock.call_args_list), 0)
+        last_body = patch_member_mock.call_args_list[-1].args[3]
+        self.assertEqual(
+            last_body["status"], "success",
+            f"member should have completed successfully (operator wait was "
+            f"credited back); got status={last_body.get('status')!r}, "
+            f"completionReason={last_body.get('completionReason')!r}",
+        )
+
+    def test_credit_accumulator_interval_union_semantics(self):
+        """Unit test for the registry's interval-union behavior: two parallel
+        waits credit only their wall-clock overlap, not their sum."""
+        import time as _t
+        from orchestrator_helpers.fireteam_confirmation_registry import (
+            begin_confirmation_wait, end_confirmation_wait,
+            get_credit_s, drop_wave_credit,
+        )
+
+        session_id = "test-session-iu"
+        wave_id = "test-wave-iu"
+        drop_wave_credit(session_id, wave_id)  # ensure clean slate
+
+        # Member A starts waiting.
+        begin_confirmation_wait(session_id, wave_id)
+        _t.sleep(0.2)
+        # Member B starts waiting WHILE A is still waiting (parallel).
+        begin_confirmation_wait(session_id, wave_id)
+        _t.sleep(0.2)
+        # Member A finishes; B still waiting (count goes 2→1, no commit yet).
+        end_confirmation_wait(session_id, wave_id)
+        _t.sleep(0.2)
+        # Member B finishes; count goes 1→0, commit total elapsed pause.
+        end_confirmation_wait(session_id, wave_id)
+
+        credit = get_credit_s(session_id, wave_id)
+        # Wall-clock pause = ~0.6s (A's start through B's end).
+        # Simple sum would be ~0.4 + 0.4 = 0.8s — wrong.
+        # Interval-union gives ~0.6s — right.
+        self.assertGreater(credit, 0.5, f"credit too low: {credit:.3f}")
+        self.assertLess(credit, 0.75,
+                        f"credit too high (simple-sum bug?): {credit:.3f}")
+        drop_wave_credit(session_id, wave_id)
+
+
+# =============================================================================
+# BUG: Fireteam members re-ran identical tools because format_chain_context
+# dropped per-tool raw output across iterations.
+# =============================================================================
+#
+# `format_chain_context` rendered the recent-window wave entries with tool
+# args + analysis but no raw `tool_output` per step. Only the very last tool
+# of the very last shown iteration got its raw output re-attached. A member
+# at iteration N saw raw output for wave N-1's last tool only, plus LLM-
+# summarized text for everything else. The Self-Check duplicate-target rule
+# in the member's system prompt asks the LLM to consult its trace to avoid
+# redundant tool calls — but the trace had already lost the per-tool result
+# detail. Empirically: dig / curl / httpx calls with identical args got
+# re-issued at iter 3 after running at iter 1.
+#
+# Fix: per-tool 200-char output preview in the wave-rendering block. Plus a
+# tool-args digest line in the older-summary tier, and a raw-output preview
+# alongside the analysis line in the single-tool branch when both exist.
+
+
+class MemberLocalProgressPreservesToolOutputRegression(unittest.TestCase):
+    """Locks the fix: a multi-iteration trace with tool outputs renders every
+    iteration's per-tool args AND a short raw-output preview, so the LLM's
+    duplicate-target Self-Check rule has data to fire on."""
+
+    def test_wave_rendering_includes_per_tool_output_preview(self):
+        from state import format_chain_context
+
+        execution_trace = [
+            # ── Iteration 1: a 3-tool wave ──
+            {
+                "iteration": 1, "phase": "informational",
+                "tool_name": "kali_shell",
+                "tool_args": {"command": "dig +short testphp.vulnweb.com A"},
+                "tool_output": "44.228.249.3",
+                "success": True,
+                "output_analysis": "DNS resolved testphp + testasp",
+                "thought": "[Wave] DNS check",
+                "reasoning": "Resolve both targets",
+            },
+            {
+                "iteration": 1, "phase": "informational",
+                "tool_name": "execute_curl",
+                "tool_args": {"args": "-IL http://testphp.vulnweb.com"},
+                "tool_output": "HTTP/1.1 200 OK\nServer: nginx/1.18\nDate: ...",
+                "success": True,
+                "output_analysis": "Live, nginx",
+                "thought": "[Wave] HTTP probe",
+            },
+            {
+                "iteration": 1, "phase": "informational",
+                "tool_name": "execute_httpx",
+                "tool_args": {"args": "-u http://testphp.vulnweb.com -silent -j"},
+                "tool_output": '{"url":"http://testphp.vulnweb.com","status_code":200}',
+                "success": True,
+                "output_analysis": "Fingerprint OK",
+                "thought": "[Wave] httpx fingerprint",
+            },
+            # ── Iteration 2: different tool to confirm it's the LATEST window ──
+            {
+                "iteration": 2, "phase": "informational",
+                "tool_name": "execute_nuclei",
+                "tool_args": {"args": "-u http://testphp.vulnweb.com -tags sqli"},
+                "tool_output": "[ALERT] sqli detected at /search?q=",
+                "success": True,
+                "output_analysis": "SQLi found",
+                "thought": "[Wave] vuln scan",
+            },
+        ]
+        rendered = format_chain_context(
+            chain_findings=[], chain_failures=[], chain_decisions=[],
+            execution_trace=execution_trace,
+            recent_iterations=20,
+        )
+
+        # Iteration 1's tool args still appear (existing contract).
+        self.assertIn("dig +short testphp.vulnweb.com A", rendered)
+        self.assertIn("-IL http://testphp.vulnweb.com", rendered)
+        self.assertIn("-u http://testphp.vulnweb.com -silent -j", rendered)
+
+        # NEW: iteration 1's tool outputs are surfaced per step, not just the
+        # LLM's analysis summary. The duplicate-target Self-Check rule needs
+        # this — pre-fix it would have seen analysis text only.
+        self.assertIn(
+            "44.228.249.3", rendered,
+            "iter 1 dig output dropped — duplicate-detect rule cannot match a "
+            "future dig with the same target against an analysis-only summary",
+        )
+        self.assertIn(
+            "HTTP/1.1 200 OK", rendered,
+            "iter 1 curl raw output dropped — LLM cannot tell from analysis "
+            "alone whether a future curl is a duplicate of this one",
+        )
+        # httpx's JSON shape preserved up to the truncation cap (200 chars).
+        self.assertIn("\"status_code\":200", rendered)
+
+        # Iteration 2 is the LAST shown iteration; its tool output also
+        # appears (covered by both the new per-tool preview AND the pre-
+        # existing 5000-char "Output (last tool)" reattachment).
+        self.assertIn("[ALERT] sqli detected", rendered)
+
+    def test_single_tool_rendering_surfaces_raw_output_alongside_analysis(self):
+        from state import format_chain_context
+
+        execution_trace = [
+            # Single-tool iteration with BOTH analysis and raw output present.
+            {
+                "iteration": 1, "phase": "informational",
+                "tool_name": "execute_curl",
+                "tool_args": {"args": "-IL http://example.com"},
+                "tool_output": "HTTP/1.1 301 Moved Permanently\nLocation: https://example.com/",
+                "success": True,
+                "output_analysis": "Redirects to HTTPS",
+            },
+            # Second iteration so the first is NOT the "last shown" (avoids
+            # the pre-existing 5000-char reattachment hiding the bug).
+            {
+                "iteration": 2, "phase": "informational",
+                "tool_name": "execute_httpx",
+                "tool_args": {"args": "-u https://example.com -j"},
+                "tool_output": '{"url":"https://example.com","status_code":200}',
+                "success": True,
+                "output_analysis": "Live on HTTPS",
+            },
+        ]
+        rendered = format_chain_context(
+            chain_findings=[], chain_failures=[], chain_decisions=[],
+            execution_trace=execution_trace,
+            recent_iterations=20,
+        )
+
+        # Iteration 1's analysis line still appears (existing OK | analysis).
+        self.assertIn("Redirects to HTTPS", rendered)
+        # NEW: raw output appears via the "Raw: ..." line, NOT only via the
+        # last-tool reattachment (iter 1 isn't last). Pre-fix the analysis
+        # text shadowed the raw response.
+        self.assertIn("HTTP/1.1 301 Moved Permanently", rendered)
+
+    def test_older_summary_tier_includes_tool_digest(self):
+        """When more iterations exist than recent_iterations, the older tier
+        compresses to one line per iteration. The new tool-digest line gives
+        the duplicate-target rule something to match on for older iters."""
+        from state import format_chain_context
+
+        # 12 iterations, recent_iterations=5 → 7 iterations land in older tier.
+        execution_trace = []
+        for i in range(1, 13):
+            execution_trace.append({
+                "iteration": i, "phase": "informational",
+                "tool_name": "execute_curl",
+                "tool_args": {"args": f"-IL http://target-{i}.example.com"},
+                "tool_output": f"HTTP/1.1 200 OK for target-{i}",
+                "success": True,
+                "output_analysis": f"target-{i} live",
+            })
+
+        rendered = format_chain_context(
+            chain_findings=[], chain_failures=[], chain_decisions=[],
+            execution_trace=execution_trace,
+            recent_iterations=5,
+        )
+
+        # Iteration 1 (older tier): existing analysis line still appears.
+        self.assertIn("target-1 live", rendered)
+        # NEW: tool digest surfaces the args so duplicate-detect can match.
+        self.assertIn("execute_curl", rendered)
+        # Specifically, an earlier-iteration target appears in the digest.
+        self.assertIn("-IL http://target-1.example.com", rendered)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
> **Depends on #117.** Please review and merge #117 first; once that merges, this PR's diff will auto-reduce to contain only the trace-preservation changes (the second of two commits on this branch).


### Summary

The renderer for a fireteam member's "Your local progress in this run" prompt block emitted per-tool args and the LLM's analysis text across iterations, but discarded raw `tool_output` after the wave completed — except for the very last tool of the very last shown iteration. This left the LLM at iteration N with no way to detect that its planned tool call was a duplicate of one already run at iteration M < N. Members re-ran identical `dig` / `curl -IL` / `httpx -u` commands across iterations. The fix preserves a short raw-output preview per tool inside the wave-rendering block and adds a tool-args digest line to the older-summary tier so the Self-Check duplicate-target rule can match against real prior tool calls.

### Problem

`agentic/state.py:format_chain_context` (around lines 1196-1490) is the renderer for the member's local-progress block, called from `agentic/orchestrator_helpers/nodes/fireteam_member_think_node.py:637-643`. Three rendering points dropped per-tool detail across iterations:

1. **Recent-window wave entries** (around lines 1389-1451): emitted tool counts, args (truncated to 300 chars), rationale (400 chars), failed-tool errors (300 chars), and the LLM's `output_analysis.interpretation` (up to 10000 chars) — but never `t.get("tool_output")`. For multi-tool waves at iter N-1, only the LLM's own summary survived into the iter-N prompt; the raw responses were gone.
2. **Recent-window single-tool entries** (around lines 1453-1475): `out_preview = (analysis or output or "")[:10000]` — the LLM's analysis shadowed the raw output. Once `output_analysis` was written, raw output became unreachable.
3. **Last-tool reattachment** (around lines 1477-1487): the only place the renderer re-attached raw output (5000-char cap). Fires for the very last tool of the very last shown iteration only.

Combined effect: the LLM at iteration N saw raw output for wave N-1's last tool only. The Self-Check duplicate-target rule in the member's system prompt (`fireteam_member_think_node.py:403-407`) instructs the LLM to consult its trace to avoid redundant tool calls — but the trace had already lost the per-tool result detail. Empirically: dig / curl / httpx calls with identical args got re-issued at iter 3 after running at iter 1, with no acknowledgement in the LLM's THOUGHT that it was repeating itself.

### Fix

`agentic/state.py` (one file):

1. **Recent-window wave rendering** — replaced the existing "Tools:" block (which listed `tool_name: args`) with one that lists each tool's args AND a short raw-output preview (200 chars, newlines collapsed to spaces) when the tool succeeded. Format:
   ```
   Tools:
     - kali_shell: {"command": "dig +short testphp.vulnweb.com A"}
       → 44.228.249.3
     - execute_curl: {"args": "-IL http://testphp.vulnweb.com"}
       → HTTP/1.1 200 OK Server: nginx/1.18 Date: ...
   ```
   Falls back to args-only when the tool produced no output. Preview reads `tool_output` first, then `output_summary` (the field name used in `_result_from_final_state`-style entries from FireteamMemberResult.execution_trace_summary).

2. **Recent-window single-tool rendering** — preserved the existing `OK | analysis-or-output` line, but added a separate `Raw: <preview>` line (300 chars) when BOTH `analysis` and raw `output` are present. This surfaces the raw response alongside the LLM's summary; pre-fix the analysis text shadowed the raw output entirely.

3. **Older-summary tier** — added a one-line tool-digest follow-up per iteration: `tools: tool_name(short_args); tool_name(short_args); ...` (each entry truncated to 80 chars). This lets the duplicate-target rule fire on iterations beyond the recent window too, without re-introducing full per-tool output for older iterations (which would blow the token budget).

4. **Last-tool 5000-char reattachment** — left untouched. It remains the rich-context window for the most recent tool call.

Token-budget impact: ~+2,500 tokens per typical member prompt (10 iterations × 5 tools × 200-char preview / ~4 chars/token). Member prompts are typically 30-50K and Opus's context is 200K, so this is well within budget. Worst case (50-iter member fully in older tier) is ~+7,500 tokens, still acceptable.

Regression test added to `agentic/tests/test_fireteam_regressions.py` as `MemberLocalProgressPreservesToolOutputRegression` with three tests:
- `test_wave_rendering_includes_per_tool_output_preview` — multi-tool wave rendered with per-tool output previews (raw responses for dig / curl / httpx visible, not just analysis text).
- `test_single_tool_rendering_surfaces_raw_output_alongside_analysis` — a two-iteration single-tool trace; iteration 1 is NOT the "last shown" so the existing 5000-char reattachment doesn't mask the bug; assertion: raw HTTP response appears alongside the LLM's analysis.
- `test_older_summary_tier_includes_tool_digest` — 12-iteration trace with `recent_iterations=5`; assertion: iteration-1 args are visible via the new tool digest line, not just the analysis summary.

### Testing

Both static and dynamic. The three new regression tests pass inside the agent container; the existing fireteam-regression suites (`FindingConversionPerItemExceptionRegression`, `WaveTimeoutPreservesPartialStateRegression`, `WaveClockExcludesConfirmationWaitRegression`, the format-renderer test in `test_fireteam_core.py`) all continue to pass — no neighboring regressions.

Runtime testing with a real multi-iteration member was impractical for the usual image-bake reason and because reproducing the duplicate-tool-call symptom end-to-end requires an LLM-in-the-loop run. The test-based dynamic verification pins the structural contract: format_chain_context now surfaces enough detail per iteration for the Self-Check rule to fire. Whether the LLM then actually uses that detail to skip duplicates is an LLM-behavior question, separate from the state-plumbing fix.

### Risk

Low-to-medium. The change adds rendered detail to every member prompt at every iteration — token consumption goes up by ~2,500 tokens for typical members. Reviewers should sanity-check the per-tool preview length (200 chars) and the older-tier digest length (80 chars per tool) against their cost-vs-signal preference. The previews are aggressively truncated to bound the impact.

Watch-out for reviewers:
- **Token cost.** The +2,500 typical / +7,500 worst case is significant for high-volume deployments. If cost is the concern, the 200-char per-tool preview is the dial — halving to 100 chars halves the impact. The older-tier digest is cheaper (80 chars × tools, not × iterations × tools_per_iter).
- **`tool_output` precedence.** The new wave-rendering reads `tool_output` first, then `output_summary` (used by FireteamMemberResult's execution_trace_summary entries). If a future code path adds a third field name for the raw output, the renderer will fall back to empty preview — the args line still appears, so no regression in behavior, just no preview.
- **Newline collapsing in the preview.** Raw outputs with significant structure (JSON, multi-line HTTP headers) are flattened to single-line via `.replace("\n", " ")`. The 200-char cap is sized so the first JSON keys or the first HTTP header line are visible; deeper structure is lost from the preview. The 5000-char "last tool" reattachment preserves the structure for the most recent tool call.
- **No empty-trace short-circuit changes.** FAPP-45's `chain_waves` addition already broke the `"No steps executed yet."` early return; this PR doesn't touch that branch. If a future maintainer routes through this code with no execution_trace AND no chain_waves AND no findings AND no failures, the early return still fires — same as before.

Backward-compatible: rendering of empty traces, prompts that don't fall into the recent window, and the JSON/text shape of all other render branches are unchanged. Server-only Python; no schema, API, or message-shape changes.

---

