### PR TITLE
fix(fireteam): per-item exception handling in ChainFindingExtract conversion

### DIFF
--- a/agentic/orchestrator_helpers/nodes/fireteam_deploy_node.py
+++ b/agentic/orchestrator_helpers/nodes/fireteam_deploy_node.py
@@ -24,7 +24,7 @@ from uuid import uuid4
 import httpx
 from langchain_core.messages import SystemMessage
 
-from state import AgentState, FireteamMemberResult
+from state import AgentState, FireteamMemberResult, ChainFindingExtract
 from orchestrator_helpers.config import get_identifiers
 from project_settings import get_setting, TOOL_MUTEX_GROUPS
 from tools import set_tenant_context, set_phase_context, set_graph_view_context
@@ -297,22 +297,30 @@ def _result_from_final_state(final_state: dict, spec: dict, member_id: str, wall
     # report pipeline joins there directly — this field is a best-effort
     # denormalization for the FireteamMember.resultBlob dump.
     findings = []
-    try:
-        from state import ChainFindingExtract
-        for f in (final_state.get("chain_findings_memory") or []):
-            if isinstance(f, dict):
-                findings.append(ChainFindingExtract(
-                    finding_type=f.get("finding_type", "custom"),
-                    severity=f.get("severity", "info"),
-                    title=f.get("title", ""),
-                    evidence=f.get("evidence", ""),
-                    related_cves=f.get("related_cves") or [],
-                    related_ips=f.get("related_ips") or [],
-                    confidence=f.get("confidence", 80),
-                    step_iteration=int(f.get("step_iteration") or 0),
-                ))
-    except Exception as e:
-        logger.debug("findings conversion skipped: %s", e)
+    for f in (final_state.get("chain_findings_memory") or []):
+        if not isinstance(f, dict):
+            continue
+        try:
+            findings.append(ChainFindingExtract(
+                finding_type=f.get("finding_type", "custom"),
+                severity=f.get("severity", "info"),
+                title=f.get("title", ""),
+                evidence=f.get("evidence", ""),
+                related_cves=f.get("related_cves") or [],
+                related_ips=f.get("related_ips") or [],
+                confidence=f.get("confidence", 80),
+                step_iteration=int(f.get("step_iteration") or 0),
+            ))
+        except Exception as e:
+            # Per-item try/except: one malformed dict no longer drops the
+            # rest of the batch. Warning level so failures are visible on
+            # the default console handler (CONSOLE_LOG_LEVEL is INFO).
+            # Offending dict is truncated to keep logs bounded when evidence
+            # fields carry large blobs.
+            logger.warning(
+                "findings conversion skipped one item: %s; offending=%s",
+                e, str(f)[:300],
+            )
 
     return FireteamMemberResult(
         member_id=member_id,

--- a/agentic/tests/test_fireteam_regressions.py
+++ b/agentic/tests/test_fireteam_regressions.py
@@ -772,5 +772,83 @@ class WaveTimeoutPreservesPartialStateRegression(unittest.IsolatedAsyncioTestCas
         self.assertEqual(result.get("findings") or [], [])
 
 
+# =============================================================================
+# BUG: Single try/except wrapped the whole findings-conversion loop at debug
+# level, dropping the entire batch on one bad item and hiding the failure.
+# =============================================================================
+#
+# Fix moved the try/except inside the loop (per-item isolation) and raised the
+# log level to warning so schema drift / malformed LLM emissions surface on
+# the default console handler (CONSOLE_LOG_LEVEL=INFO).
+
+
+class FindingConversionPerItemExceptionRegression(unittest.TestCase):
+    """Locks the fix: a malformed finding skips itself, not the whole batch,
+    and emits a warning-level log identifying the failure."""
+
+    def test_one_bad_finding_doesnt_drop_the_batch(self):
+        from orchestrator_helpers.nodes.fireteam_deploy_node import (
+            _result_from_final_state,
+        )
+
+        final_state = {
+            "chain_findings_memory": [
+                {
+                    "finding_type": "service_identified",
+                    "severity": "info",
+                    "title": "good 1",
+                    "evidence": "nginx 1.18 detected",
+                    "confidence": 80,
+                    "step_iteration": 1,
+                },
+                {
+                    # Pydantic v2 ValidationError: "high" can't coerce to int.
+                    "finding_type": "vulnerability_confirmed",
+                    "severity": "high",
+                    "title": "bad item — confidence is a string",
+                    "evidence": "unparseable confidence",
+                    "confidence": "high",
+                    "step_iteration": 1,
+                },
+                {
+                    "finding_type": "configuration_found",
+                    "severity": "low",
+                    "title": "good 2",
+                    "evidence": "CORS *",
+                    "confidence": 90,
+                    "step_iteration": 2,
+                },
+            ],
+            "execution_trace": [],
+            "target_info": {},
+            "parent_target_info": {},
+        }
+        spec = {"name": "Scout", "task": "t", "tools": []}
+
+        with self.assertLogs(
+            "orchestrator_helpers.nodes.fireteam_deploy_node", level="WARNING",
+        ) as cm:
+            result = _result_from_final_state(final_state, spec, "m-0", 1.0)
+
+        # Both valid findings survive — pre-fix the whole batch would be [].
+        self.assertEqual(
+            len(result["findings"]), 2,
+            f"expected 2 valid findings to survive (good 1, good 2); got "
+            f"{len(result['findings'])}: {[f.get('title') for f in result['findings']]}",
+        )
+        titles = [f["title"] for f in result["findings"]]
+        self.assertIn("good 1", titles)
+        self.assertIn("good 2", titles)
+        self.assertNotIn("bad item — confidence is a string", titles)
+
+        # A WARNING was emitted that mentions the failure. Either the offending
+        # dict's title or the Pydantic field name ('confidence') is enough.
+        joined = "\n".join(cm.output)
+        self.assertTrue(
+            "bad item" in joined or "confidence" in joined,
+            f"warning log did not surface the bad item: {joined!r}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
> **Depends on #117.** Please review and merge #117 first; once that merges, this PR's diff will auto-reduce to contain only the per-item validation changes (the second of two commits on this branch).


### Summary

Findings conversion from `chain_findings_memory` (member ReAct state) into `ChainFindingExtract` Pydantic instances was wrapped in a single try/except that logged at debug level. One malformed dict dropped the entire batch and the failure was invisible on the default console handler. The fix moves the try/except inside the loop (per-item isolation) and raises the level to warning so schema drift / malformed LLM emissions surface.

### Problem

`agentic/orchestrator_helpers/nodes/fireteam_deploy_node.py:_result_from_final_state` (around lines 299-315 in the original) converted member findings to `ChainFindingExtract` instances inside one big try-block:

```python
findings = []
try:
    from state import ChainFindingExtract
    for f in (final_state.get("chain_findings_memory") or []):
        if isinstance(f, dict):
            findings.append(ChainFindingExtract(...))
except Exception as e:
    logger.debug("findings conversion skipped: %s", e)
```

Three issues:

1. **Broad batch failure.** The try wrapped the entire `for` loop, so a single Pydantic `ValidationError` raised on any one finding aborted iteration and silently produced `findings=[]`. Subsequent good items never got built.
2. **Hidden from operators.** `agentic/logging_config.py` declares `CONSOLE_LOG_LEVEL = logging.INFO` and `FILE_LOG_LEVEL = logging.DEBUG`. The `logger.debug(...)` call landed in `agent.log` but never on the operator's stdout — and the failure produced no metric, alert, or higher-level log.
3. **Realistic triggers exist.** `ChainFindingExtract` at `agentic/state.py:252-273` declares `confidence: int` and `related_cves: List[str]` / `related_ips: List[str]`. Plausible LLM emissions break validation: `"confidence": "high"` (str → int), `"related_cves": "CVE-2024-1234"` (scalar → list), `"title": 42` (int → str under Pydantic v2 strict-str). Any one of these would null out a member's entire findings array.

### Fix

`agentic/orchestrator_helpers/nodes/fireteam_deploy_node.py`:

1. Moved `ChainFindingExtract` to the top-level `from state import ...` line, removing the inline import-inside-try. ImportErrors now propagate naturally (which is what we want — a broken module import is a bug, not data).
2. Restructured the conversion loop with per-item try/except: each `ChainFindingExtract(...)` construction is guarded independently. A malformed dict now skips itself and the loop continues with the next item.
3. Raised log level from `debug` to `warning` and included the offending dict (truncated to 300 chars) plus the Pydantic validation error message, so failures appear on the default console handler and a postmortem grep of `agent.log` carries the schema-relevant payload.

Non-dict items still skip silently via `continue` (preserves the original `if isinstance(f, dict):` behavior — these are structural issues, not validation failures, and shouldn't pollute the warning log).

Regression test added to `agentic/tests/test_fireteam_regressions.py` as a new class `FindingConversionPerItemExceptionRegression`. The test constructs a `final_state` with three findings (good, bad, good) where the middle item has `"confidence": "high"` (provokes a Pydantic ValidationError) and asserts: (a) the result has 2 findings (NOT 0), (b) the two valid titles are present, (c) a WARNING-level log was emitted that names the bad item. Uses `unittest.assertLogs` to capture and inspect the warning.

### Testing

Both static and dynamic. The regression test passes inside the agent container; the existing `FindingStepIterationPreservedRegression` and `WaveTimeoutPreservesPartialStateRegression` tests continue to pass — no neighboring regressions.

Runtime testing against a real fireteam wave with a deliberately malformed LLM payload was impractical (would require either MITMing the Anthropic API response or temporarily editing the member's parse path to inject a bad dict — both heavier than a unit test, and the test asserts the structural contract directly). The agent container's source is also COPY'd at build time rather than bind-mounted, so a full `docker compose build agent` would be needed before any live operator-driven repro could exercise the change at runtime.

### Risk

Very low. The change is a pure defensive-coding improvement: error-handling becomes more granular, logging becomes more visible. No structural change to the data flow, no schema change, no API change. Backward-compatible: the `findings = []` array still gets populated for all valid items, and downstream consumers (`_patch_member` resultBlob, `fireteam_collect_node` chain_findings_memory roll-up) see the same shape they always did — just without the silent-drop failure mode.

Watch-out for reviewers:
- **`ChainFindingExtract` model_config not changed.** Pydantic v2's default `extra='ignore'` still silently strips unexpected LLM-emitted fields (`description`, `remediation`, etc.). The verdict flagged this as a separate concern; adding `extra='forbid'` would turn LLM extras into validation failures and lose otherwise-good findings — net-negative. Leaving model_config alone keeps that behavior unchanged. A schema-drift visibility ticket could land later with `extra='allow'` + a post-construction check on `model_extra`.
- **Warning log can now be noisy on a malformed-LLM-emission run.** Each bad dict gets one warning line. At default INFO-level console logging, this is the desired surface; if a future change moves console floor to WARNING-only, these would still appear (and arguably should). No new metric/alert was added — purely text logs.
- **The non-dict `continue` is silent.** Non-dict entries in `chain_findings_memory` would indicate a structural issue upstream (some node wrote a non-dict to the list). Currently silent; if you want that to log too, it's a one-line addition. Left silent to match the pre-fix behavior.

Server-only Python. No webapp / API / schema impact.

---

