### PR TITLE
fix: add trailing slashes to COPY destinations for BuildKit compat

### DIFF
--- a/agentic/Dockerfile
+++ b/agentic/Dockerfile
@@ -86,8 +86,8 @@ ENV DOTNET_ROOT="/usr/share/dotnet"
 
 # Copy requirements first for better caching.
 # NOTE: build context is the project root (./), not ./agentic — see docker-compose.yml
-COPY agentic/requirements.txt .
-COPY agentic/requirements-kb.txt .
+COPY agentic/requirements.txt ./
+COPY agentic/requirements-kb.txt ./
 
 # Core Python dependencies (always installed)
 RUN pip install --no-cache-dir -r requirements.txt

--- a/guinea_pigs/dvws-node/xss-lab/Dockerfile
+++ b/guinea_pigs/dvws-node/xss-lab/Dockerfile
@@ -42,7 +42,7 @@ WORKDIR /app
 COPY package.json ./
 RUN npm install --omit=dev --no-audit --no-fund --loglevel=error
 
-COPY . .
+COPY . ./
 
 EXPOSE 3001
 

--- a/recon_orchestrator/Dockerfile
+++ b/recon_orchestrator/Dockerfile
@@ -10,11 +10,11 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies
-COPY requirements.txt .
+COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application code
-COPY *.py .
+COPY *.py ./
 
 # Run the FastAPI application
 CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8010"]

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -19,7 +19,7 @@ FROM node:22-slim AS builder
 WORKDIR /app
 
 COPY --from=deps /app/node_modules ./node_modules
-COPY . .
+COPY . ./
 
 ARG REDAMON_VERSION=0.0.0
 ENV NEXT_PUBLIC_REDAMON_VERSION=$REDAMON_VERSION


### PR DESCRIPTION
## Summary
<!-- What changed and why? 1-3 bullet points. -->

- Fixed `Dockerfile` syntax across multiple components by appending a trailing slash (`/`) to `COPY` destination paths instead of leaving them as a bare dot (`.`).
- Resolves a strict compilation failure triggered by newer versions of Docker BuildKit: `"When using COPY with more than one source file, the destination must be a directory and end with a /"`.

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test

## Component(s)
<!-- Which services does this touch? -->
- [ ] webapp (Next.js)
- [ ] recon-orchestrator (Python)
- [ ] agent (Python)
- [ ] kali-sandbox / MCP servers
- [ ] docs / wiki
- [x] other: Dockerfiles

## How to Test
<!-- Steps to verify this change works. -->

1. Use a machine running a modern version of Docker with BuildKit active.
2. Run the main installation script: `./redamon.sh install --gvm --kbase`
3. Verify that all services successfully compile their Docker layers past the `COPY` commands without crashing.

## Checklist
- [x] I have tested this change locally with `docker compose`
- [x] I have not included real-world target data
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read and agree to the [DISCLAIMER.md](DISCLAIMER.md)

## Related Issues
I didnt found the issue being reported (but experienced it), so i fixed it.
