### PR TITLE
fix(ip-filter): strip whitespace and brackets before parsing IP strings

### DIFF
--- a/recon/main_recon_modules/ip_filter.py
+++ b/recon/main_recon_modules/ip_filter.py
@@ -29,7 +29,13 @@ def is_non_routable_ip(ip_str: str) -> bool:
 
     Covers RFC 1918 private, loopback, link-local, CGNAT (100.64.0.0/10),
     and IETF reserved ranges.
+
+    Leading/trailing whitespace and IPv6 bracket notation (``[::1]``) are
+    stripped before parsing so callers don't need to normalise the string
+    themselves.
     """
+    # Normalise: strip whitespace, remove surrounding brackets for IPv6
+    ip_str = ip_str.strip().strip("[]")
     try:
         addr = ipaddress.ip_address(ip_str)
     except ValueError:

--- a/tests/test_ip_filter.py
+++ b/tests/test_ip_filter.py
@@ -53,6 +53,18 @@ class TestIsNonRoutableIp(unittest.TestCase):
     def test_ipv6_public(self):
         self.assertFalse(is_non_routable_ip("2607:f8b0:4004:800::200e"))
 
+    def test_strip_whitespace_from_public_ip(self):
+        """IPs surrounded by spaces must still be classified correctly."""
+        self.assertFalse(is_non_routable_ip(" 8.8.8.8 "))
+        self.assertFalse(is_non_routable_ip("\t1.1.1.1\n"))
+        self.assertTrue(is_non_routable_ip("  10.0.0.1  "))
+
+    def test_ipv6_bracket_notation(self):
+        """Bracket-wrapped IPv6 addresses (HTTP Host header style) must parse."""
+        self.assertTrue(is_non_routable_ip("[::1]"))
+        self.assertFalse(is_non_routable_ip("[2607:f8b0:4004:800::200e]"))
+        self.assertTrue(is_non_routable_ip(" [::1] "))
+
 
 class TestCollectCdnIps(unittest.TestCase):
 


### PR DESCRIPTION
## Problem

`is_non_routable_ip()` passed raw IP strings directly to `ipaddress.ip_address()`, which raises `ValueError` for:

- **Leading/trailing whitespace** — e.g. `" 8.8.8.8 "` from HTTP header parsing
- **IPv6 bracket notation** — e.g. `"[::1]"` or `"[2607:f8b0:...]"` used in HTTP `Host` headers and log output

In both cases the function falls into the `except ValueError: return True` branch, silently **mis-classifying valid public IPs as non-routable**, causing them to be skipped by OSINT enrichment without any warning.

## Fix

Add a normalisation step at the top of `is_non_routable_ip()`:

```python
ip_str = ip_str.strip().strip("[]")
```

This is a minimal, safe change that does not affect the behaviour for well-formed input.

## Tests

Added `test_strip_whitespace_from_public_ip` and `test_ipv6_bracket_notation` to `tests/test_ip_filter.py`. All 24 tests pass.

```
24 passed in 0.08s
```