### PR TITLE
Configure remote Ollama and fix Docker broker image pulls

### DIFF
--- a/docker_broker/broker.py
+++ b/docker_broker/broker.py
@@ -41,6 +41,7 @@ import json
 import os
 import re
 import sys
+from urllib.parse import parse_qs, urlsplit
 
 # --------------------------------------------------------------------------
 # Policy (allowlist). Seeded from env so it can be kept in sync with V3.
@@ -122,12 +123,22 @@ def _log(msg: str) -> None:
 def _image_allowed(image: str) -> bool:
     if not image:
         return False
-    if image in ALLOWED_IMAGES:
-        return True
-    # also accept the implicit ":latest" form (docker normalizes "alpine" ->
-    # "alpine:latest"); accept if either spelling is allowlisted.
-    if ":" not in image.split("/")[-1] and f"{image}:latest" in ALLOWED_IMAGES:
-        return True
+    # Docker's pull API canonicalizes Docker Hub names to docker.io/<repo> and
+    # official images to docker.io/library/<name>.  Compare those canonical
+    # spellings with the short allowlist form, but do not strip other registries.
+    candidates = {image}
+    if image.startswith("docker.io/"):
+        short = image[len("docker.io/"):]
+        candidates.add(short)
+        if short.startswith("library/"):
+            candidates.add(short[len("library/"):])
+    for candidate in candidates:
+        if candidate in ALLOWED_IMAGES:
+            return True
+        # Also accept the implicit ":latest" spelling.
+        if ":" not in candidate.split("/")[-1] \
+                and f"{candidate}:latest" in ALLOWED_IMAGES:
+            return True
     return False
 
 
@@ -302,11 +313,12 @@ def inject_limits(cfg: dict) -> dict:
 
 def validate_pull(path: str) -> tuple[bool, str]:
     """Validate docker pull (POST /images/create?fromImage=...&tag=...)."""
-    q = path.split("?", 1)[1] if "?" in path else ""
-    params = dict(p.split("=", 1) for p in q.split("&") if "=" in p)
-    from_image = params.get("fromImage", "")
-    tag = params.get("tag", "")
-    # URL-decode minimally (handle %2F etc. is rare for these)
+    # Docker percent-encodes repository separators (for example
+    # docker.io%2Fprojectdiscovery%2Fnuclei).  parse_qs performs the required
+    # decoding before the value is compared with the allowlist.
+    params = parse_qs(urlsplit(path).query, keep_blank_values=True)
+    from_image = params.get("fromImage", [""])[0]
+    tag = params.get("tag", [""])[0]
     image = f"{from_image}:{tag}" if tag else from_image
     if _image_allowed(image) or _image_allowed(from_image):
         return True, "ok"

--- a/docker_broker/test_policy.py
+++ b/docker_broker/test_policy.py
@@ -123,6 +123,12 @@ broker.ALLOWED_RW_PREFIXES = ["/tmp/redamon"]
 print("=== pull policy ===")
 ok, _ = broker.validate_pull("/v1.43/images/create?fromImage=projectdiscovery/naabu&tag=latest")
 check("ALLOW pull allowlisted", ok is True)
+ok, _ = broker.validate_pull("/v1.51/images/create?fromImage=docker.io%2Fprojectdiscovery%2Fnaabu&tag=latest")
+check("ALLOW encoded Docker Hub pull", ok is True)
+ok, _ = broker.validate_pull("/v1.51/images/create?fromImage=ghcr.io%2Fzaproxy%2Fzaproxy&tag=stable")
+check("ALLOW encoded GHCR pull", ok is True)
+ok, _ = broker.validate_pull("/v1.51/images/create?fromImage=docker.io%2Flibrary%2Falpine&tag=latest")
+check("ALLOW encoded official Docker Hub pull", ok is True)
 ok, _ = broker.validate_pull("/v1.43/images/create?fromImage=attacker/evil&tag=latest")
 check("DENY pull non-allowlisted", ok is False)
 

--- a/webapp/src/components/settings/LlmProviderForm.tsx
+++ b/webapp/src/components/settings/LlmProviderForm.tsx
@@ -354,6 +354,9 @@ export function LlmProviderForm({ userId, provider, existingProviderTypes = [], 
                 const preset = OPENAI_COMPAT_PRESETS.find(p => p.name === e.target.value)
                 if (preset && preset.baseUrl) {
                   updateForm('baseUrl', preset.baseUrl)
+                  if (preset.defaultModel) {
+                    updateForm('modelIdentifier', preset.defaultModel)
+                  }
                 }
               }}
             >

--- a/webapp/src/lib/llmProviderPresets.ts
+++ b/webapp/src/lib/llmProviderPresets.ts
@@ -11,11 +11,18 @@ export interface LlmProviderPreset {
   name: string
   baseUrl: string
   description: string
+  defaultModel?: string
 }
 
 export type ProviderIcon = ComponentType<SVGProps<SVGSVGElement> & { size?: number | string }>
 
 export const OPENAI_COMPAT_PRESETS: LlmProviderPreset[] = [
+  {
+    name: 'Ollama remoto (10.172.124.113)',
+    baseUrl: 'http://10.172.124.113:11434/v1',
+    description: 'gpt-oss:latest en la red local',
+    defaultModel: 'gpt-oss:latest',
+  },
   {
     name: 'Ollama',
     baseUrl: 'http://host.docker.internal:11434/v1',


### PR DESCRIPTION
* Add a remote Ollama preset so Amon can connect to an Ollama instance running on another machine in the local network, including automatic selection of the preset's default model.
* Fix Docker broker image-pull validation by correctly decoding URL-encoded image names and accepting Docker Hub canonical image names such as `docker.io/library/alpine`.
* Add policy tests covering encoded Docker Hub, GHCR, and official Docker Hub image pull requests.

## Type of Change

* [x] Bug fix
* [x] New feature
* [ ] Refactor (no behavior change)
* [ ] Documentation
* [x] Test

## Component(s)

* [x] webapp (Next.js)
* [ ] recon-orchestrator (Python)
* [ ] agent (Python)
* [ ] kali-sandbox / MCP servers
* [ ] docs / wiki
* [x] other: Docker broker

## How to Test

1. Start the project with `docker compose` and confirm that the web application and Docker broker are running.

2. Run the Docker broker policy tests:

   ```bash
   python3 docker_broker/test_policy.py
   ```

3. Verify that the following allowlisted image pull formats are accepted:

   * `projectdiscovery/naabu:latest`
   * `docker.io/projectdiscovery/naabu:latest`
   * `ghcr.io/zaproxy/zaproxy:stable`
   * `docker.io/library/alpine:latest`

4. Verify that a non-allowlisted image such as `attacker/evil:latest` is rejected.

5. Open the LLM provider settings in the web application.

6. Select the remote Ollama preset.

7. Confirm that the base URL is automatically set to:

   ```text
   http://10.172.0.113:11434/v1
   ```

8. Confirm that the model identifier is automatically set to:

   ```text
   gpt-oss:latest
   ```

9. From an Amon deployment running inside a virtual machine or on another computer in the same network, verify that it can connect to the remote Ollama API and successfully execute a model request.

## Checklist

* [ ] I have tested this change locally with `docker compose`
* [x] I have not included real-world target data
* [ ] My commits follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/)
* [ ] I have read and agree to the [DISCLAIMER.md](DISCLAIMER.md)

## Screenshots

Add a screenshot of the LLM provider settings showing the remote Ollama preset and the automatically populated model identifier.

## Related Issues

No related issue.