### PR TITLE
fix(agent): stream OpenAI-compatible LLM responses to avoid timeout in ollama cloud

### DIFF
--- a/agentic/orchestrator_helpers/llm_setup.py
+++ b/agentic/orchestrator_helpers/llm_setup.py
@@ -176,6 +176,16 @@ def setup_llm(
                 temperature=custom_llm_config.get("temperature", 0),
                 max_tokens=custom_llm_config.get("maxTokens", 16384),
             )
+            if ptype == "openai_compatible":
+                # Consume OpenAI-compatible responses as SSE while preserving
+                # the existing ainvoke() contract. Long-running cloud-backed
+                # runtimes such as Ollama can otherwise leave a non-streaming
+                # request silent until the full completion is ready, causing
+                # an intermediary/read timeout even though generation is
+                # healthy. stream_usage keeps token accounting intact when
+                # ChatOpenAI aggregates the chunks into one AIMessage.
+                kwargs["streaming"] = True
+                kwargs["stream_usage"] = True
             base_url = custom_llm_config.get("baseUrl")
             ssl_verify = custom_llm_config.get("sslVerify", True)
             # SSRF guard (I15) + TLS-off-on-public guard (I16). Localhost/LAN
@@ -209,6 +219,8 @@ def setup_llm(
             api_key=openai_compat_api_key or "ollama",
             base_url=openai_compat_base_url,
             temperature=0,
+            streaming=True,
+            stream_usage=True,
         )
 
     elif provider == "openrouter":


### PR DESCRIPTION
## Summary

* Enable SSE response streaming for custom and legacy OpenAI-compatible providers while preserving the existing `ainvoke()` contract.
* Prevent long-running cloud-backed completions, such as Ollama Cloud requests, from hitting the 120-second proxy or read timeout while generation is still progressing normally.
* Preserve token accounting through `stream_usage=True`.
* Keep the behavior of canonical OpenAI providers unchanged.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor — no behavior change
* [ ] Documentation
* [ ] Test

## Component(s)

* [ ] `webapp` — Next.js
* [ ] `recon-orchestrator` — Python
* [x] `agent` — Python
* [ ] `kali-sandbox` / MCP servers
* [ ] Docs / Wiki
* [ ] Other: ___

## How to Test

### 1. Configure an OpenAI-compatible provider backed by Ollama

```text
Base URL: http://host.docker.internal:11434/v1
Model Identifier: glm-5.2:cloud
```

### 2. Build and start the agent

```bash
docker compose up -d --build agent
```

### 3. Run a long completion

Start or resume an agent conversation that produces a long-running LLM completion.

### 4. Verify SSE streaming

Confirm that:

* Ollama handles the request using SSE.
* The completion succeeds.
* The request does not return a `502` error.
* The request does not raise an `APITimeoutError` after 120 seconds while generation is still healthy.
* Canonical OpenAI providers are not forced to use streaming.

## Checklist

* [x] I have tested this change locally using Docker Compose.
* [x] I have not included real-world target data.
* [x] My commits follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/).
* [ ] I have read and agree to [`DISCLAIMER.md`](DISCLAIMER.md).

## Related Issues

No related issues.