### PR TITLE
fix: self-heal query_graph model parameters

### DIFF
--- a/agentic/tools.py
+++ b/agentic/tools.py
@@ -493,8 +493,13 @@ Cypher Query:"""
 
         # Prefer the per-session LLM (task-isolated) so concurrent projects run
         # text-to-Cypher on their OWN model; fall back to the manager's llm.
+        from orchestrator_helpers.llm_retry import retry_llm_call
         llm = current_llm.get() or self.llm
-        response = await llm.ainvoke(prompt)
+        response = await retry_llm_call(
+            llm,
+            prompt,
+            label="query_graph text-to-cypher",
+        )
         from orchestrator_helpers.json_utils import normalize_content
         return self._extract_cypher_from_response(normalize_content(response.content))
 


### PR DESCRIPTION
## Summary
- route `query_graph` text-to-Cypher generation through the shared `retry_llm_call` helper
- automatically remove unsupported `temperature`/reasoning parameters when a provider rejects them
- preserve the existing per-session LLM selection and Cypher extraction behavior

## Problem
Some OpenAI-compatible providers reject RedAmon's configured `temperature=0` with `invalid temperature: only 1 is allowed`. The main reasoning path already self-healed this response, but `query_graph` called `llm.ainvoke()` directly, so all three graph attempts failed before Cypher reached Neo4j.

## Validation
- `python -m py_compile /app/tools.py`
- 22 LLM retry/self-healing tests passed in the production agent container
- 21 graph-view/query tests passed in the production agent container
- runtime session verification confirmed the temperature rejection was healed, Cypher was generated and tenant-filtered, and `query_graph` completed successfully